### PR TITLE
Route phone keyboard text directly to X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ locked by the release manifest.
   pointer motion could mask that fault, and why the direct X11 route fixes the
   local defect without claiming a universal upstream guarantee
 
+### Fixed
+
+- route layout-representable UU native-phone-keyboard text through the
+  authenticated X11/XTEST helper after Unicode normalization, avoiding the
+  same nested RDP keyboard conversion that lost accepted physical keys
+- coalesce each helper request and enable `TCP_NODELAY`, removing the observed
+  roughly 41 ms loopback request delay without changing input semantics
+
+### Validation
+
+- all 40 source, shell, documentation, migration, and helper-build tests pass
+- an isolated fixed-alphabet Unicode request returned all 52 source records on
+  `route=x11-text`, while X11 observed all 52 press/release transitions in the
+  exact expected order
+- the operator confirmed normal phone-keyboard typing was fixed; the first 72
+  bounded live text calls all used `route=x11-text`, matched their requested
+  counts, returned `error=0`, and completed in 0-2 ms
+
 ## [0.2.0] - 2026-07-18
 
 Union release that preserves the `v0.1.0` fallback while packaging the later

--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ Requested ports and fixed displays are checked before use. A conflicting
 non-GNOME listener fails closed, and an installer error restarts a bridge that
 was active before the attempted upgrade.
 
-For a new installation, the default 8 ms text-key delay prevents UU's phone
-keyboard from overwhelming the Wine-to-FreeRDP input boundary. An upgrade from
-`v0.1.0` preserves that release's unpaced behavior as `0`. The broker confirms
-that the relay window has focus before acknowledging an input request and sends
-translated text one character chord at a time. Values from 0 through 50 ms are
-accepted; change the delay only when a controlled test supports it.
+On the compatible `rdp` route, the default 8 ms text-key delay prevents UU's
+phone keyboard from overwhelming the Wine-to-FreeRDP input boundary. An
+upgrade from `v0.1.0` preserves that release's unpaced behavior as `0`. The
+broker confirms that the relay window has focus before acknowledging an input
+request and sends translated text one character chord at a time. Values from 0
+through 50 ms are accepted; change the delay only when a controlled test
+supports it. The opt-in `x11` route bypasses this RDP pacing boundary after it
+has normalized the complete representable phone-text request.
 
 Physical-key pacing defaults to `0`, preserving the ordinary path on hosts
 that already work. If slow typing succeeds but fast physical-key input omits
@@ -109,22 +111,24 @@ accepted broker segment. It never retries or synthesizes a key. See the
 [validated recovery note](docs/xrdp-and-keyboard-recovery.md) before changing
 this host-specific setting.
 
-If broker metadata shows accepted physical-key calls but the nested
-Wine/FreeRDP route still loses fast keys on an Xorg or XRDP desktop, the
-opt-in direct route removes only that final keyboard hop:
+If broker metadata shows accepted physical-key or normalized phone-text calls
+but the nested Wine/FreeRDP route still loses fast keys on an Xorg or XRDP
+desktop, the opt-in direct route removes only that final keyboard hop:
 
 ```bash
 ./install.sh --skip-packages --skip-account-login \
   --keyboard-route x11 --physical-key-delay-ms 0
 ```
 
-Mouse, video, clipboard, and Unicode phone text continue through the proven
-RDP relay. Physical keys alone go through an authenticated loopback helper and
-XTEST into the selected X11 desktop. The global default remains `rdp`; `auto`
-selects the direct route only for an X11 target. If preflight cannot verify the
-target display or helper, startup retains the compatible RDP route and the
-verifier reports that an explicitly requested X11 route is inactive. No event
-is replayed after an ambiguous partial injection.
+Mouse, video, and clipboard continue through the proven RDP relay. Physical
+keys and layout-representable phone text go through an authenticated loopback
+helper and XTEST into the selected X11 desktop. Phone text is still normalized
+into ordinary virtual-key chords before that boundary; unsupported Unicode
+fails explicitly rather than becoming an unrelated key. The global default
+remains `rdp`; `auto` selects the direct route only for an X11 target. If
+preflight cannot verify the target display or helper before injection, the
+request safely uses the compatible RDP route. No event is replayed after an
+ambiguous partial injection.
 
 On the validated XRDP workstation, the first live direct-UU run produced 256
 content-free sampled physical-key calls on `route=x11`; every sampled call
@@ -132,6 +136,19 @@ returned its requested single event with `error=0`. The operator reported that
 typing became very smooth and that almost all prior omissions were resolved.
 This is strong practical acceptance, while deliberately not claiming that an
 upstream controller can never omit an event under every network condition.
+Post-`v0.2.0` source also includes an isolated phone-text acceptance test. A
+fixed 26-letter Unicode batch crossed the Wine broker on `route=x11-text` and
+arrived as all 52 ordered X11 press/release transitions. Run it without
+touching the live desktop:
+
+```bash
+./scripts/test-x11-phone-text.sh
+```
+
+After live deployment, the operator confirmed that normal phone-keyboard
+typing was fixed. The first 72 bounded phone-text calls all used
+`route=x11-text`, returned their complete requested counts with `error=0`, and
+completed in 0-2 ms. The logs contained no character values or typed content.
 
 If individual keys lag or disappear while direct RDP remains responsive, check
 the transport before changing input code:
@@ -240,6 +257,7 @@ Phone / Windows / macOS UU controller
    Ubuntu-Desktop-Relay   bounded named-pipe broker
        SDL FreeRDP          |             |
              |              | RDP         | optional physical keys
+             |              |             | + normalized phone text
              +--------------+             v
                     |             native X11/XTEST helper
              RDP on 127.0.0.1              |
@@ -257,10 +275,11 @@ UU sees one ordinary Windows desktop window. SDL FreeRDP relays that window to
 GNOME Remote Desktop, which owns supported GNOME capture and input. The
 launcher discovers the D-Bus of the live GNOME Shell, including XRDP sessions
 that use a private session bus, and keeps the RDP hop local to the host. When
-Wine denies `SendInput` from UU's service token, a bounded broker repeats the
-same input request from a normal user Wine process. On an explicitly selected
-X11 target, physical keys can instead bypass the nested RDP input conversion;
-all other channels keep the original relay.
+Wine denies `SendInput` from UU's service token, so a bounded broker repeats
+the same input request from a normal user Wine process. On an explicitly
+selected X11 target, physical keys and normalized, layout-representable phone
+text can instead bypass the nested RDP input conversion; video, mouse,
+clipboard, and all non-keyboard channels keep the original relay.
 
 [Read the complete architecture](docs/architecture.md).
 The [debugging journey](docs/debugging-journey.md) records the failed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,21 +104,23 @@ window and confirms it became the foreground window within a bounded 300 ms
 before calling `SendInput`. It returns the real count and error code to UU only
 after that boundary succeeds.
 
-On an X11 target with `UURB_KEYBOARD_ROUTE=x11`, the broker recognizes only
-bounded, non-Unicode keyboard-only arrays and sends their physical scan events
-to `uu-x11-input` over a token-authenticated loopback socket. The native helper
-preflights the whole array, maps the established XFree86 scan-code set to X11
-keycodes, and uses XTEST on the discovered live desktop. Mouse, mixed arrays,
-and Unicode phone text remain on the RDP route. A helper that is absent,
-unreachable before injection, or presented with an unsupported event safely
-falls back to RDP. A communication failure after injection begins returns an
-error without replay, preventing duplicate keys. Held keys are released when
-the broker disconnects, and helper exit restarts the supervised bridge.
+On an X11 target with `UURB_KEYBOARD_ROUTE=x11`, the broker sends bounded
+keyboard-only arrays to `uu-x11-input` over a token-authenticated loopback
+socket. Physical arrays are mapped directly. Unicode phone-text arrays are
+first normalized into ordinary virtual-key chords, so neither Unicode values
+nor text cross the helper protocol. The native helper preflights the complete
+translated array, maps the established XFree86 scan-code set to X11 keycodes,
+and uses XTEST on the discovered live desktop. Mouse and mixed arrays remain
+on the RDP route. A helper that is absent, unreachable before injection, or
+presented with an unsupported event safely falls back to RDP. A communication
+failure after injection begins returns an error without replay, preventing
+duplicate keys. Held keys are released when the broker disconnects, and
+helper exit restarts the supervised bridge.
 
 The direct route removes two conversions—Wine `SendInput` into SDL FreeRDP and
-FreeRDP into GNOME RDP—for the one category that remained lossy on the affected
-XRDP workstation. It is not enabled globally because the original RDP route is
-known-good on other hosts and is still required for Wayland targets.
+FreeRDP into GNOME RDP—for the keyboard categories that remained lossy on the
+affected XRDP workstation. It is not enabled globally because the original RDP
+route is known-good on other hosts and is still required for Wayland targets.
 
 No key code, Unicode character, clipboard payload, or text is written to the
 diagnostic logs.
@@ -131,12 +133,14 @@ IME instead submits batches marked `KEYEVENTF_UNICODE`. SDL FreeRDP consumes
 physical scancodes and misreads Wine's synthetic Unicode events, typically as
 one repeated letter or punctuation key. The bridge routes Unicode batches
 directly to the broker, where each representable character is converted with
-`VkKeyScanW` into an ordinary virtual-key chord before it reaches SDL FreeRDP.
-Character chords are submitted separately with a persistent, configurable 8 ms
-delay so the SDL/RDP event loop can consume each chord before UU sends the next
-one. The original request count is returned to UU only after focus is confirmed
-and every translated event is accepted. Unsupported characters fail explicitly
-rather than being emitted as an unrelated key.
+`VkKeyScanW` into an ordinary virtual-key chord. On `rdp`, character chords are
+submitted separately with a persistent, configurable 8 ms delay so the
+SDL/RDP event loop can consume each chord before UU sends the next one. On
+`x11`, the complete translated request is preflighted and injected through the
+authenticated XTEST helper, bypassing both nested RDP keyboard conversions.
+The original request count is returned to UU only after every translated event
+is accepted. Unsupported characters fail explicitly rather than being emitted
+as an unrelated key.
 
 Physical-key segments are unchanged by default. On the RDP route, an optional
 0-50 ms delay can add back-pressure after each accepted segment. On the direct

--- a/docs/debugging-journey.md
+++ b/docs/debugging-journey.md
@@ -530,11 +530,12 @@ UU controller -> normal-token broker -> authenticated X11 helper
               -> XTEST + XSync -> XRDP Xorg desktop
 ```
 
-Video, mouse, clipboard, and phone text remain on the established relay. The
-physical keyboard no longer passes through Wine's input queue and two nested
-RDP keyboard conversions. An isolated test preserved all 58 requested
-press/release transitions, and the accepted live sample contained 256
-successful `route=x11` calls while the operator reported smooth typing.
+At the `v0.2.0` acceptance boundary, video, mouse, clipboard, and phone text
+remained on the established relay. The physical keyboard no longer passed
+through Wine's input queue and two nested RDP keyboard conversions. An
+isolated test preserved all 58 requested press/release transitions, and the
+accepted live sample contained 256 successful `route=x11` calls while the
+operator reported smooth typing.
 
 Those observations localize the dominant workstation defect to the old local
 nested route or its resulting back-pressure. They do not identify one exact
@@ -542,3 +543,47 @@ proprietary UU, Wine, SDL FreeRDP, GNOME RDP, or libei function as the sole
 culprit, and they cannot guarantee that the controller or network upstream of
 the broker will never omit an event. This is why the fix removes the measured
 bad boundary instead of adding retries or making a broader unsupported claim.
+
+## 17. Reuse the proven direct route for normalized phone text
+
+A later live A/B test made the remaining boundary equally clear. The UU
+computer-keyboard panel was exact through `route=x11`, while the phone's normal
+keyboard visibly omitted several characters. For one fixed 13-character ASCII
+trial, all 13 text requests reached the current broker, each was normalized,
+and every call returned its complete source count with `error=0`. Only eleven
+characters appeared in the target. The controller and broker had therefore
+done their work; loss remained after Wine accepted the translated chords on
+the nested RDP route.
+
+The narrow correction keeps `VkKeyScanW` normalization unchanged, then offers
+the complete translated keyboard-only array to the already authenticated X11
+helper before requesting relay focus or calling `SendInput`. A failure known
+to happen during preflight can still use RDP because nothing was injected. An
+ambiguous partial X11 failure returns an error and is never replayed.
+
+The broker also used to send the small request header and event array in two
+loopback TCP writes. Nagle/delayed-ACK interaction made otherwise healthy X11
+requests take about 41 ms. The request is now one packet and the socket enables
+`TCP_NODELAY`; new live physical-key metadata measured 0 ms broker/helper
+round trips without changing event semantics.
+
+An isolated acceptance test sent a fixed 26-letter Unicode batch into the
+Windows broker. The broker reported `route=x11-text`, returned all 52 source
+records with `error=0`, and the X11 target observed exactly 26 presses and 26
+releases in order. The reusable test is:
+
+```bash
+./scripts/test-x11-phone-text.sh
+```
+
+This improves layout-representable text. It does not turn XTEST into a general
+Unicode or IME protocol: a character that `VkKeyScanW` cannot represent still
+fails explicitly, and Wayland hosts retain the compatible RDP route.
+
+The deployed workstation then completed the real acceptance test through the
+phone's normal keyboard. The operator reported that typing was fixed. The
+first 72 bounded live text records independently used `route=x11-text`, each
+returned its complete source count with `error=0`, and broker/helper processing
+took 0-2 ms. No typed character or key value was recorded. This confirms that
+the successful visible result came from the new route rather than the still-
+available RDP fallback or the computer-keyboard panel.

--- a/docs/mobile-keyboard-parity-handoff.md
+++ b/docs/mobile-keyboard-parity-handoff.md
@@ -191,8 +191,10 @@ rg 'route=broker .*error=0' "$bridge" | tail -n 10
 ```
 
 A working normal-phone-keyboard commit has `text=normalized`, a result equal to
-the original count, and `error=0`. Post-release text logs also show
-`focus=ready`, `paced-text=N`, and `text-delay-ms=N`; physical-key logs use
+the original count, and `error=0`. On the compatible RDP route, post-release
+text logs also show `focus=ready`, `paced-text=N`, and `text-delay-ms=N`. On a
+post-`v0.2.0` direct X11 route, representable text instead reports
+`route=x11-text` and `focus=bypassed`. Physical-key logs use
 `category=keyboard`, `route=rdp|x11`, `paced-physical=N`, and
 `physical-delay-ms=N`. Do not require those newer fields from `v0.1.0`.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,12 +243,14 @@ delay. On a verified Xorg/XRDP target, select the native physical-key route:
 ./scripts/verify.sh --quick
 ```
 
-The verifier must report `direct X11 physical-key helper is active`, and a
-fresh UU computer-keyboard event must report `category=keyboard route=x11`
-with a matching result and `error=0`. Mouse, video, clipboard, and phone text
-remain on RDP. If explicit X11 preflight cannot verify the target display, the
-service remains usable on RDP but verification fails so the fallback is not
-mistaken for the requested test. Restore the baseline with:
+The verifier must report `direct X11 physical-key helper is active`. A fresh
+UU computer-keyboard event must report `category=keyboard route=x11`, while a
+representable normal-phone-keyboard commit reports
+`category=text route=x11-text`; both require a matching result and `error=0`.
+Mouse, video, and clipboard remain on RDP. If explicit X11 preflight cannot
+verify the target display, the service remains usable on RDP but verification
+fails so the fallback is not mistaken for the requested test. Restore the
+baseline with:
 
 ```bash
 ./install.sh --skip-packages --skip-account-login \

--- a/docs/update-handoff.md
+++ b/docs/update-handoff.md
@@ -125,10 +125,13 @@ and the target session is confirmed X11:
 ```
 
 Reconnect UU, type the alphabet rapidly, press Enter, and test Ctrl+A/C/V.
-Require both the visible result and a fresh content-free
-`category=keyboard route=x11 ... result=1 error=0` record. Restore
+Then repeat the ASCII acceptance string with the phone's normal keyboard.
+Require both visible results plus fresh content-free
+`category=keyboard route=x11 ... error=0` and
+`category=text route=x11-text ... error=0` records. Restore
 `--keyboard-route rdp` if the target is Wayland or the helper cannot preflight
-the display.
+the display. The isolated fixed-alphabet acceptance can be repeated without
+touching the live desktop with `./scripts/test-x11-phone-text.sh`.
 
 ## Failure handoff
 

--- a/docs/xrdp-and-keyboard-recovery.md
+++ b/docs/xrdp-and-keyboard-recovery.md
@@ -151,7 +151,7 @@ A paced successful call reports `category=keyboard`, `focus=ready`,
 count, and `error=0`. The logs never record a key code, character, clipboard
 payload, address, account identifier, or typed text.
 
-## Direct X11 physical-key route
+## Direct X11 keyboard route
 
 Pacing improved this workstation but did not remove every omission. A later
 12 ms capture recorded 219 physical-key broker calls; every recorded call
@@ -167,9 +167,10 @@ therefore bypass the lossy nested keyboard conversion while preserving all
 other working channels:
 
 ```text
-UU physical key -> Wine hook -> user-token broker -> X11 helper -> Xorg
+UU physical key or normalized phone text
+  -> Wine hook -> user-token broker -> X11 helper -> Xorg
 
-UU video/mouse/text -> existing SDL FreeRDP -> GNOME RDP -> desktop
+UU video/mouse/clipboard -> existing SDL FreeRDP -> GNOME RDP -> desktop
 ```
 
 Enable this route only on a verified Xorg/XRDP target:
@@ -180,14 +181,15 @@ Enable this route only on a verified Xorg/XRDP target:
 ./scripts/verify.sh --quick
 ```
 
-The native helper uses XTEST on the discovered desktop, accepts only physical
-keyboard arrays over an authenticated loopback socket, and is supervised by
-the existing service. It preflights each complete array. Unavailable or
-unsupported input falls back before injection; a failure after possible
-injection is returned without replay, avoiding duplicate keys. Disconnect
-releases tracked held keys. With the direct route, the physical delay is a
-minimum key-hold interval rather than a delay after every down and up event;
-zero keeps the path non-blocking.
+The native helper uses XTEST on the discovered desktop and accepts only
+physical keyboard arrays over an authenticated loopback socket. Phone Unicode
+is converted into those ordinary key chords inside the broker before crossing
+that boundary. The helper is supervised by the existing service and preflights
+each complete array. Unavailable or unsupported input falls back before
+injection; a failure after possible injection is returned without replay,
+avoiding duplicate keys. Disconnect releases tracked held keys. With the
+direct route, the physical delay is a minimum key-hold interval rather than a
+delay after every down and up event; zero keeps the path non-blocking.
 
 Restore the universally compatible path without deleting UU state:
 
@@ -205,6 +207,11 @@ Before live deployment, an isolated Xvfb test sent the full alphabet together
 with Ctrl+A and Enter as one fast stream. XTEST observed all 58 transitions in
 order: 29 key presses and 29 key releases, including both Ctrl and Enter
 transitions.
+
+A later isolated phone-text test sent a fixed 26-letter Unicode batch through
+the Windows broker. It returned all 52 source records on `route=x11-text`, and
+XTEST delivered all 26 presses and 26 releases in exact order. Reproduce this
+without touching the live desktop with `./scripts/test-x11-phone-text.sh`.
 
 The subsequent real UU controller test reached the newly restarted broker, not
 an older RDP process: all 256 sampled physical-key records reported
@@ -228,5 +235,6 @@ fix or isolate either the fresh XRDP desktop or pacing as sufficient by itself.
 A controlled 12 ms trial was the final pacing experiment. It retained
 occasional omissions despite successful broker results, so further delay was
 rejected in favor of the direct X11 route above. Reconnect UU after any route
-change and require fresh `category=keyboard route=x11 result=1 error=0`
-records before attributing a manual test to that route.
+change and require fresh `category=keyboard route=x11 ... error=0` and, for
+the normal phone keyboard, `category=text route=x11-text ... error=0` records
+before attributing a manual test to that route.

--- a/scripts/test-x11-phone-text.sh
+++ b/scripts/test-x11-phone-text.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/uurb-x11-text.XXXXXX")"
+wine_prefix="$temporary_dir/wine"
+ready_file="$temporary_dir/x11-input.port"
+broker_log="$temporary_dir/input-broker.log"
+xev_log="$temporary_dir/xev.log"
+token="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+xvfb_pid=""
+xev_pid=""
+helper_pid=""
+broker_pid=""
+
+cleanup() {
+    local pid
+
+    for pid in "$broker_pid" "$helper_pid" "$xev_pid" "$xvfb_pid"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    if [[ -d "$wine_prefix" ]]; then
+        WINEPREFIX="$wine_prefix" /opt/wine-stable/bin/wineserver -k \
+            >/dev/null 2>&1 || true
+    fi
+    wait 2>/dev/null || true
+    if [[ "$temporary_dir" == "${TMPDIR:-/tmp}/uurb-x11-text."* ]]; then
+        rm -rf -- "$temporary_dir"
+    fi
+}
+trap cleanup EXIT
+
+for command in Xvfb xev xdotool xdpyinfo python3 stdbuf \
+    x86_64-w64-mingw32-gcc /opt/wine-stable/bin/wine \
+    /opt/wine-stable/bin/wineboot /opt/wine-stable/bin/winepath; do
+    command -v "$command" >/dev/null 2>&1 || {
+        printf 'missing acceptance-test command: %s\n' "$command" >&2
+        exit 1
+    }
+done
+
+display=""
+for number in {88..99}; do
+    if [[ ! -S "/tmp/.X11-unix/X$number" ]]; then
+        display=":$number"
+        break
+    fi
+done
+if [[ -z "$display" ]]; then
+    printf 'no free isolated X display in :88..:99\n' >&2
+    exit 1
+fi
+
+"$repo_dir/scripts/build-compat.sh" "$temporary_dir/compat" >/dev/null
+x86_64-w64-mingw32-gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -o "$temporary_dir/uu-text-probe.exe" \
+    "$repo_dir/tests/probes/uu_text_probe.c"
+
+Xvfb "$display" -screen 0 800x600x24 -ac -nolisten tcp \
+    >"$temporary_dir/xvfb.log" 2>&1 &
+xvfb_pid=$!
+for _ in {1..50}; do
+    if DISPLAY="$display" xdpyinfo >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+DISPLAY="$display" xdpyinfo >/dev/null
+
+DISPLAY="$display" stdbuf -oL -eL xev -geometry 400x240 \
+    >"$xev_log" 2>&1 &
+xev_pid=$!
+xev_window=""
+for _ in {1..50}; do
+    xev_window="$(DISPLAY="$display" xdotool search --name 'Event Tester' \
+        2>/dev/null | head -n 1 || true)"
+    [[ -n "$xev_window" ]] && break
+    sleep 0.1
+done
+if [[ -z "$xev_window" ]]; then
+    printf 'isolated X11 event window did not appear\n' >&2
+    exit 1
+fi
+DISPLAY="$display" xdotool windowfocus "$xev_window"
+
+DISPLAY="$display" UURB_X11_INPUT_TOKEN="$token" \
+    "$temporary_dir/compat/uu-x11-input" --ready-file "$ready_file" \
+    --min-hold-ms 0 >"$temporary_dir/x11-input.log" 2>&1 &
+helper_pid=$!
+for _ in {1..50}; do
+    [[ -s "$ready_file" ]] && break
+    sleep 0.1
+done
+if [[ ! -s "$ready_file" ]]; then
+    printf 'isolated X11 helper did not become ready\n' >&2
+    exit 1
+fi
+port="$(tr -d '[:space:]' < "$ready_file")"
+
+DISPLAY="$display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    /opt/wine-stable/bin/wineboot -u >/dev/null 2>&1
+broker_log_windows="$(DISPLAY="$display" WINEPREFIX="$wine_prefix" \
+    WINEDEBUG=-all /opt/wine-stable/bin/winepath -w "$broker_log")"
+DISPLAY="$display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    UU_INPUT_BROKER_LOG="$broker_log_windows" \
+    UURB_X11_INPUT_PORT="$port" UURB_X11_INPUT_TOKEN="$token" \
+    UURB_TEXT_KEY_DELAY_MS=8 UURB_PHYSICAL_KEY_DELAY_MS=0 \
+    /opt/wine-stable/bin/wine "$temporary_dir/compat/uu-input-broker.exe" \
+    >"$temporary_dir/broker-stdio.log" 2>&1 &
+broker_pid=$!
+sleep 0.5
+
+DISPLAY="$display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    /opt/wine-stable/bin/wine "$temporary_dir/uu-text-probe.exe"
+sleep 0.2
+
+python3 - "$xev_log" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(errors="replace")
+matches = re.findall(
+    r"(KeyPress|KeyRelease) event,.*?keysym 0x[0-9a-f]+, ([a-z])\)",
+    text,
+    flags=re.DOTALL,
+)
+expected = []
+for character in "abcdefghijklmnopqrstuvwxyz":
+    expected.extend((("KeyPress", character), ("KeyRelease", character)))
+if matches != expected:
+    raise SystemExit(
+        f"X11 text mismatch: observed {len(matches)} of {len(expected)} "
+        "expected transitions"
+    )
+print("x11-transitions=52/52 order=exact")
+PY
+
+if ! rg -q 'category=text .*route=x11-text .*result=52 error=0' \
+    "$broker_log"; then
+    printf 'broker did not confirm the direct X11 phone-text route\n' >&2
+    exit 1
+fi
+printf 'broker-route=x11-text result=52 error=0\n'
+printf 'isolated phone-text acceptance passed\n'

--- a/src/uu_input_broker.c
+++ b/src/uu_input_broker.c
@@ -186,6 +186,7 @@ static BOOL connect_x11_input(void)
     struct sockaddr_in address;
     uurb_x11_handshake handshake;
     uurb_x11_response response;
+    BOOL no_delay = TRUE;
     DWORD socket_timeout_ms = 1000;
     WSADATA data;
 
@@ -208,6 +209,8 @@ static BOOL connect_x11_input(void)
     setsockopt(x11_input_socket, SOL_SOCKET, SO_RCVTIMEO,
                (const char *)&socket_timeout_ms,
                sizeof(socket_timeout_ms));
+    setsockopt(x11_input_socket, IPPROTO_TCP, TCP_NODELAY,
+               (const char *)&no_delay, sizeof(no_delay));
     ZeroMemory(&address, sizeof(address));
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -266,8 +269,10 @@ static BOOL input_to_x11_event(const INPUT *input,
 static x11_route_result send_x11_inputs(DWORD count, const INPUT *inputs,
                                         DWORD *error, BOOL *considered)
 {
-    uurb_x11_key_event events[INPUT_BRIDGE_MAX_INPUTS];
-    uurb_x11_request request;
+    struct {
+        uurb_x11_request request;
+        uurb_x11_key_event events[INPUT_BRIDGE_MAX_INPUTS];
+    } packet;
     uurb_x11_response response;
     DWORD index;
 
@@ -282,26 +287,27 @@ static x11_route_result send_x11_inputs(DWORD count, const INPUT *inputs,
     }
     *considered = TRUE;
     for (index = 0; index < count; index++) {
-        if (!input_to_x11_event(&inputs[index], &events[index]))
+        if (!input_to_x11_event(&inputs[index], &packet.events[index]))
             return X11_ROUTE_NOT_USED;
     }
     if (!connect_x11_input())
         return X11_ROUTE_NOT_USED;
 
-    request.magic = UURB_X11_INPUT_MAGIC;
-    request.sequence = (uint32_t)InterlockedIncrement(&x11_sequence);
-    request.count = count;
-    request.reserved = 0;
-    if (!socket_write_all(x11_input_socket, &request, sizeof(request)) ||
-        !socket_write_all(x11_input_socket, events,
-                          (int)(count * sizeof(events[0]))) ||
+    packet.request.magic = UURB_X11_INPUT_MAGIC;
+    packet.request.sequence = (uint32_t)InterlockedIncrement(&x11_sequence);
+    packet.request.count = count;
+    packet.request.reserved = 0;
+    if (!socket_write_all(
+            x11_input_socket, &packet,
+            (int)(sizeof(packet.request) +
+                  count * sizeof(packet.events[0]))) ||
         !socket_read_all(x11_input_socket, &response, sizeof(response))) {
         close_x11_input_socket();
         *error = ERROR_CONNECTION_ABORTED;
         return X11_ROUTE_FAILED;
     }
     if (response.magic != UURB_X11_INPUT_MAGIC ||
-        response.sequence != request.sequence) {
+        response.sequence != packet.request.sequence) {
         close_x11_input_socket();
         *error = ERROR_INVALID_DATA;
         return X11_ROUTE_FAILED;
@@ -510,32 +516,6 @@ static DWORD send_relay_inputs(DWORD source_count, const INPUT *source,
     *focus_wait_ms = 0;
     *route = "rdp";
 
-    x11_result = send_x11_inputs(source_count, source, error,
-                                 &x11_considered);
-    if (x11_result == X11_ROUTE_SUCCESS) {
-        *route = "x11";
-        return source_count;
-    }
-    if (x11_result == X11_ROUTE_FAILED) {
-        *route = "x11-error";
-        return 0;
-    }
-    if (x11_considered)
-        *route = "rdp-fallback";
-
-    *focus_ready = request_relay_focus(focus_wait_ms);
-    if (!*focus_ready) {
-        *error = GetLastError();
-        for (index = 0; index < source_count; index++) {
-            if (source[index].type == INPUT_KEYBOARD &&
-                (source[index].ki.dwFlags & KEYEVENTF_UNICODE) != 0) {
-                *normalized_unicode = TRUE;
-                break;
-            }
-        }
-        return 0;
-    }
-
     if (!translate_inputs(source_count, source, translated, &translated_count,
                           segments, &segment_count, normalized_unicode)) {
         *error = ERROR_NO_UNICODE_TRANSLATION;
@@ -545,6 +525,40 @@ static DWORD send_relay_inputs(DWORD source_count, const INPUT *source,
     if (translated_count == 0) {
         *error = ERROR_SUCCESS;
         return source_count;
+    }
+
+    /*
+     * Unicode phone text is normalized into ordinary key chords before this
+     * boundary.  Sending those complete chords through the same authenticated
+     * X11 helper as physical keys avoids the nested Wine/FreeRDP keyboard hop.
+     * If preflight cannot use X11, no event has been injected and the existing
+     * RDP route remains a safe fallback.  A partial/ambiguous X11 failure is
+     * never replayed.
+     */
+    x11_result = send_x11_inputs(translated_count, translated, error,
+                                 &x11_considered);
+    if (x11_result == X11_ROUTE_SUCCESS) {
+        if (*normalized_unicode)
+            *route = "x11-text";
+        else
+            *route = "x11";
+        return source_count;
+    }
+    if (x11_result == X11_ROUTE_FAILED) {
+        if (*normalized_unicode)
+            *route = "x11-text-error";
+        else
+            *route = "x11-error";
+        return 0;
+    }
+    if (x11_considered)
+        *route = *normalized_unicode ? "rdp-text-fallback" :
+                                       "rdp-fallback";
+
+    *focus_ready = request_relay_focus(focus_wait_ms);
+    if (!*focus_ready) {
+        *error = GetLastError();
+        return 0;
     }
 
     for (index = 0; index < segment_count; index++) {
@@ -724,7 +738,8 @@ static void serve_client(HANDLE pipe)
                 (unsigned long)first_type, (unsigned long)first_flags,
                 normalized_unicode ? "normalized" : "unchanged",
                 route,
-                strcmp(route, "x11") == 0 ? "bypassed" :
+                (strcmp(route, "x11") == 0 ||
+                 strcmp(route, "x11-text") == 0) ? "bypassed" :
                 (focus_ready ? "ready" : "timeout"),
                 (unsigned long)focus_wait_ms,
                 (unsigned long)paced_characters,

--- a/tests/probes/uu_text_probe.c
+++ b/tests/probes/uu_text_probe.c
@@ -1,0 +1,103 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+
+#define INPUT_BRIDGE_MAGIC 0x42525555UL
+#define INPUT_BRIDGE_PIPE L"\\\\.\\pipe\\uurb-input-v1"
+#define ACCEPTANCE_CHARACTERS 26UL
+#define ACCEPTANCE_INPUTS (ACCEPTANCE_CHARACTERS * 2UL)
+
+typedef struct input_bridge_request {
+    DWORD magic;
+    DWORD count;
+    DWORD input_size;
+} input_bridge_request;
+
+typedef struct input_bridge_response {
+    DWORD result;
+    DWORD error;
+} input_bridge_response;
+
+static BOOL write_all(HANDLE handle, const void *buffer, DWORD size)
+{
+    const BYTE *position = (const BYTE *)buffer;
+
+    while (size > 0) {
+        DWORD written = 0;
+
+        if (!WriteFile(handle, position, size, &written, NULL) || written == 0)
+            return FALSE;
+        position += written;
+        size -= written;
+    }
+    return TRUE;
+}
+
+static BOOL read_all(HANDLE handle, void *buffer, DWORD size)
+{
+    BYTE *position = (BYTE *)buffer;
+
+    while (size > 0) {
+        DWORD received = 0;
+
+        if (!ReadFile(handle, position, size, &received, NULL) ||
+            received == 0)
+            return FALSE;
+        position += received;
+        size -= received;
+    }
+    return TRUE;
+}
+
+int main(void)
+{
+    input_bridge_request request;
+    input_bridge_response response;
+    INPUT inputs[ACCEPTANCE_INPUTS];
+    HANDLE pipe;
+    DWORD index;
+
+    ZeroMemory(inputs, sizeof(inputs));
+    for (index = 0; index < ACCEPTANCE_CHARACTERS; index++) {
+        WCHAR character = (WCHAR)(L'a' + index);
+        INPUT *press = &inputs[index * 2];
+        INPUT *release = &inputs[index * 2 + 1];
+
+        press->type = INPUT_KEYBOARD;
+        press->ki.wScan = character;
+        press->ki.dwFlags = KEYEVENTF_UNICODE;
+        *release = *press;
+        release->ki.dwFlags |= KEYEVENTF_KEYUP;
+    }
+
+    if (!WaitNamedPipeW(INPUT_BRIDGE_PIPE, 5000)) {
+        fprintf(stderr, "input broker pipe was not ready: %lu\n",
+                (unsigned long)GetLastError());
+        return 1;
+    }
+    pipe = CreateFileW(INPUT_BRIDGE_PIPE, GENERIC_READ | GENERIC_WRITE, 0,
+                       NULL, OPEN_EXISTING, 0, NULL);
+    if (pipe == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "could not open input broker pipe: %lu\n",
+                (unsigned long)GetLastError());
+        return 1;
+    }
+
+    request.magic = INPUT_BRIDGE_MAGIC;
+    request.count = ACCEPTANCE_INPUTS;
+    request.input_size = sizeof(INPUT);
+    if (!write_all(pipe, &request, sizeof(request)) ||
+        !write_all(pipe, inputs, sizeof(inputs)) ||
+        !read_all(pipe, &response, sizeof(response))) {
+        fprintf(stderr, "input broker request failed: %lu\n",
+                (unsigned long)GetLastError());
+        CloseHandle(pipe);
+        return 1;
+    }
+    CloseHandle(pipe);
+
+    printf("requested=%lu result=%lu error=%lu\n",
+           (unsigned long)request.count, (unsigned long)response.result,
+           (unsigned long)response.error);
+    return response.result == request.count && response.error == 0 ? 0 : 1;
+}

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -206,6 +206,16 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn("INPUT_BRIDGE_FOCUS_TIMEOUT_MS", broker)
         self.assertIn("Sleep(text_key_delay_ms)", broker)
         self.assertIn('L"UURB_TEXT_KEY_DELAY_MS"', broker)
+        self.assertIn('"x11-text"', broker)
+        self.assertIn('"rdp-text-fallback"', broker)
+        self.assertIn("TCP_NODELAY", broker)
+        translated = broker.index("if (!translate_inputs")
+        direct_x11 = broker.index("x11_result = send_x11_inputs", translated)
+        relay_focus = broker.index(
+            "*focus_ready = request_relay_focus", direct_x11
+        )
+        self.assertLess(translated, direct_x11)
+        self.assertLess(direct_x11, relay_focus)
         self.assertIn("Sleep(physical_key_delay_ms)", broker)
         self.assertIn('L"UURB_PHYSICAL_KEY_DELAY_MS"', broker)
         self.assertIn('category = "keyboard"', bridge)


### PR DESCRIPTION
## What changed

- normalize representable UU phone text as before, then route the complete physical chord array through the authenticated X11/XTEST helper
- retain the compatible RDP fallback only when X11 preflight fails before injection
- coalesce helper packets and enable TCP_NODELAY to remove the observed 41 ms loopback delay
- add a reproducible isolated Wine-broker-to-X11 phone-text acceptance test and update operational documentation

## Root cause and impact

The phone sent every tested Unicode request and the broker returned success, but the old Wine to SDL FreeRDP to GNOME RDP path still dropped visible characters. Reusing the proven direct X11 route removes that lossy local conversion while preserving video, mouse, clipboard, Wayland defaults, and no-replay safety.

## Validation

- 40 repository tests passed
- isolated fixed alphabet: 52/52 X11 transitions in exact order, route=x11-text, error=0
- live bridge verifier fully passed
- operator confirmed ordinary phone keyboard typing is fixed
- first 72 bounded live phone-text calls all matched counts with error=0 in 0-2 ms
- UU computer-keyboard control remains correct on route=x11