### PR TITLE
Fix automated Codex repair handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ locked by the release manifest.
 
 - opt-in daily official-release checks and a 15-minute health monitor that
   persist across reboot without periodically restarting a healthy bridge
-- resumable Codex repair workspaces using explicit `gpt-5.6-sol` and `xhigh`
+- resumable Codex repair workspaces using explicit `codex-auto-review` and
+  `medium`
   settings, atomic thread/session state, structured output, bounded retry, and
   an independently rerun test suite
 - immutable `track-rdp-broker-20260724` and `track-direct-x11-20260724` aliases that name
@@ -39,6 +40,10 @@ locked by the release manifest.
 
 - use the installed `codex-auto-review` model at medium reasoning effort for
   resumable repair tasks by default, while preserving explicit overrides
+- persist the absolute Codex executable selected during configuration so NVM
+  installations remain reachable from the smaller systemd user-service `PATH`
+- snapshot the complete two-host keyboard and troubleshooting handoff into
+  every repair checkout before starting or resuming Codex
 
 - wait for the actual FreeRDP relay window after Wine's short-lived Unix
   launcher exits, verify that the spawned GNOME daemon owns its configured

--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ ID, raw production log, screenshot, or private desktop content is committed.
 - [Update handoff for another operator](docs/update-handoff.md)
 - [Input behavior tracks](docs/release-tracks.md)
 - [Automatic checks and resumable repair](docs/automatic-updates.md)
+- [Automated repair agent handoff](docs/automated-repair-agent-handoff.md)
 - [Mobile-keyboard parity handoff](docs/mobile-keyboard-parity-handoff.md)
 - [XRDP client stall and UU keyboard recovery](docs/xrdp-and-keyboard-recovery.md)
 - [Unattended startup after reboot](docs/unattended-startup.md)

--- a/docs/automated-repair-agent-handoff.md
+++ b/docs/automated-repair-agent-handoff.md
@@ -1,0 +1,200 @@
+# Automated Repair Agent Handoff
+
+This is the required operational memory for a Codex session launched by the
+UU automatic updater. It summarizes the two-host investigation and points to
+the detailed, versioned evidence. Read it before changing patch manifests,
+input routing, process supervision, installer handling, or recovery behavior.
+
+The updater copies task-specific release evidence into
+`build/automated-repair/CONTEXT.md`. That generated file is authoritative for
+the candidate version, hashes, staging paths, selected behavior track, and
+safety boundaries. This handoff supplies the engineering history that must not
+be rediscovered or accidentally undone.
+
+## Objective
+
+Produce a reviewable, proprietary-binary-free source repair for a newly
+observed UU release while preserving the behavior already validated on two
+different Ubuntu hosts. An automated session may audit, compare, write source
+or a draft manifest, and run tests. It may not approve its own binary
+interpretation or deploy to the live Wine prefix.
+
+## The Two Validated Host Profiles
+
+The hosts intentionally use different input tracks. Neither is a generic
+"older" or "newer" machine.
+
+### Known-good Wayland reference
+
+The `OptiPlex-7090` reference used Ubuntu 24.04, GNOME 46 on Wayland, Wine 11,
+and the compatible RDP/broker route. Both UU's computer-keyboard panel and the
+phone's native keyboard were smooth. This host proved that the original
+broker/RDP behavior can be correct and must remain available. Do not enable
+XTEST globally or reinterpret this profile as broken merely because the other
+workstation needs direct X11 input.
+
+The complete snapshot and privacy-safe comparison procedure are in
+[Mobile Keyboard Parity Handoff](mobile-keyboard-parity-handoff.md).
+
+### Affected XRDP/Xorg workstation
+
+The second workstation runs the live GNOME desktop inside XRDP/Xorg. On this
+host, Wine accepted fast physical-key and normalized phone-text requests, but
+events could disappear after broker acceptance in the nested
+Wine `SendInput` -> SDL FreeRDP -> GNOME RDP -> Xorg chain. Deliberate slow
+typing and 8 ms/12 ms pacing improved the symptom but did not eliminate it.
+
+The validated profile is therefore:
+
+```text
+UURB_KEYBOARD_ROUTE=x11
+UURB_PHYSICAL_KEY_DELAY_MS=0
+```
+
+The authenticated loopback X11/XTEST helper handles physical keys and
+layout-representable normalized phone text. Video, mouse, and clipboard remain
+on the local RDP relay. The detailed recovery and rollback are in
+[XRDP Client Stall and UU Keyboard Recovery](xrdp-and-keyboard-recovery.md).
+
+## Keyboard Boundaries That Must Stay Separate
+
+UU exposes two keyboard surfaces:
+
+1. The computer-keyboard panel emits ordinary physical Windows key events.
+2. The phone's normal keyboard/IME emits `KEYEVENTF_UNICODE` text batches.
+
+An acceptance test for one surface does not validate the other. The phone text
+path must normalize each representable character with `VkKeyScanW` into
+ordinary modifier and virtual-key chords. Unsupported Unicode fails explicitly
+instead of becoming an unrelated key.
+
+Important evidence from the XRDP workstation:
+
+- The early broken phone path could turn letters into one repeated key and
+  numbers into punctuation.
+- A later fixed 13-character A/B run reached the broker 13/13 times but only
+  11 characters were visible through the nested RDP route.
+- The isolated direct-X11 phone test preserved 52/52 transitions in exact
+  order.
+- The first 72 privacy-safe live phone-text calls used `route=x11-text`,
+  returned exact result counts with `error=0`, and completed in 0–2 ms.
+- The computer-keyboard panel was separately confirmed complete.
+
+The helper still accepts bounded, non-Unicode keyboard records only. Unicode
+interpretation belongs in the broker.
+
+## Proven Troubleshooting Lessons
+
+Preserve these decisions:
+
+1. **Wine service-token input denial:** UU's signed Windows HID driver cannot
+   run under Wine. The audited hook and normal-user broker adapt only the
+   required `SendInput` boundary.
+2. **API success is not visible delivery:** a matching `SendInput` result
+   proves Wine accepted a request, not that every nested RDP hop delivered it.
+3. **No replay after ambiguity:** delayed originals can still arrive. Never
+   retry a possibly delivered key, modifier, or shortcut.
+4. **Pacing is evidence, not the final XRDP fix:** 8 ms and 12 ms reduced
+   pressure but retained the lossy conversion chain. The direct X11 route is
+   the validated solution on the affected Xorg host.
+5. **Small-packet latency was real:** writing the X11 request header and events
+   separately caused about 41 ms latency. One coalesced write plus
+   `TCP_NODELAY` reduced it to 0–2 ms.
+6. **Source and runtime are different:** `git pull` does not update
+   `~/.local/bin`, the Wine compatibility binaries, or the active service.
+   Preserve runtime-digest verification.
+7. **Long-session input loss had a separate cause:** Ubuntu's libei 1.2.1
+   leaked received keymap file descriptors. The bridge-local reviewed backport,
+   higher supervised descriptor limit, and bounded guard address it without
+   replacing a desktop-wide library.
+8. **Multi-homed adapter selection can affect UU transport:** keep the
+   network-interface filter fail-open and host-specific. Do not modify system
+   routes, DNS, NetworkManager, or firewall rules as an input workaround.
+9. **Controller transport and host injection are different boundaries:**
+   direct RDP can remain healthy while a forced/high-latency UU relay drops
+   keys before they reach the hook. Do not synthesize host-side retries.
+10. **XRDP client stalls are not bridge patch failures:** reset a stale
+    Windows App client before restarting XRDP. XRDP, VNC, dynamic resolution,
+    and the UU private capture canvas are related operationally but use
+    distinct listeners.
+11. **Process exits need bounded recovery:** Wine launcher exit alone must not
+    create a restart storm. Preserve systemd rate limits, health confirmation,
+    and the hardened behavior-track snapshots.
+12. **Logs are privacy-bounded:** routine logging stops after quotas and never
+    records keycodes or typed content. A quiet bounded log is not proof that an
+    input API was never called.
+
+The chronological evidence is in
+[Debugging Journey](debugging-journey.md), and the reusable investigation
+method is in [Methodology and Toolkit](methodology-and-toolkit.md).
+
+## Automated Repair Action Contract
+
+The updater-launched Codex session owns only its private repair checkout.
+
+It may:
+
+- inspect the generated task context and non-executing staged candidate;
+- use `strings`, `xxd`, `objdump`, PE parsers, and repository audit scripts;
+- compare complete hashes, sections, functions, signatures, and control flow;
+- update compatibility source, tests, and documentation;
+- create a manifest only with a non-approved review state;
+- run focused tests and the complete proprietary-binary-free unit suite;
+- return `ready_for_review`, `no_change`, or `blocked` through the required
+  output schema.
+
+It must not:
+
+- run `sudo`, push, publish, or touch the source clone;
+- edit the live Wine prefix, account state, keyring, desktop, or systemd units;
+- execute an unknown installer outside the explicit staging sandbox;
+- copy proprietary executables into Git;
+- mark a new binary manifest `approved`;
+- change the selected RDP/X11 behavior track;
+- trade safety for an uninterrupted automatic deployment.
+
+If the wrapper cannot be extracted without execution, return a precise blocked
+result requesting the documented root-managed, network-isolated staging step.
+Do not weaken the gate.
+
+## Required Reading Order
+
+1. Generated `build/automated-repair/CONTEXT.md`
+2. This handoff
+3. [Upstream Maintenance](upstream-maintenance.md)
+4. [Security](security.md)
+5. [Input Behavior Tracks](release-tracks.md)
+6. [Automatic Checks and Resumable Repair](automatic-updates.md)
+7. [Debugging Journey](debugging-journey.md)
+8. [Mobile Keyboard Parity Handoff](mobile-keyboard-parity-handoff.md)
+9. [XRDP Client Stall and UU Keyboard Recovery](xrdp-and-keyboard-recovery.md)
+10. [Troubleshooting](troubleshooting.md)
+
+## Evidence Required Before Any Live Upgrade
+
+Automated completion is not live approval. A maintainer must still verify:
+
+- complete installer and target-binary hashes;
+- patch signatures and their surrounding instruction semantics;
+- patch, expected-state verification, and byte-identical restore;
+- no proprietary or private artifacts in Git;
+- complete unit-suite success;
+- disposable Wine/Windows behavior where required;
+- controller video, mouse, reconnect, computer-keyboard, and native-phone
+  keyboard acceptance;
+- the selected host track remains unchanged;
+- rollback is available before touching the healthy live relay.
+
+The normal phone-keyboard acceptance string is `abcXYZ123,.!?`. On the direct
+X11 track, require fresh content-free `category=keyboard route=x11` and
+`category=text route=x11-text` records with matching result counts and
+`error=0`. On the compatible RDP track, preserve its already-validated broker
+behavior rather than forcing the X11 helper.
+
+## Privacy
+
+Do not commit completed host handoff records, raw Codex JSONL, UU/NetEase logs,
+installer archives, Wine prefixes, account identifiers, device identifiers,
+network addresses, tokens, passwords, browser profiles, or desktop captures.
+Keep task evidence under the updater's mode-0700 private state directory and
+summarize only non-sensitive engineering conclusions in tracked documentation.

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -29,6 +29,13 @@ with `model_reasoning_effort="medium"`. Both values are explicit in
 silently inherit a later interactive default. Codex must already be logged in
 for the same Unix user.
 
+The configurator also records the absolute executable returned by
+`command -v codex`. This matters when Codex was installed under NVM: the
+systemd user manager intentionally has a smaller `PATH` than an interactive
+shell. The updater invokes that stored executable for both rate-limit queries
+and `codex exec`, instead of assuming the shell can discover it later. Use
+`--codex /absolute/path/to/codex` when selecting a different installation.
+
 The monitor queries Codex included-usage rate limits immediately before each
 automatic repair attempt. It runs Codex only when every reported window is at
 or below `codex_max_used_percent`, which defaults to 20. Purchased credits and
@@ -95,6 +102,14 @@ When the official endpoint reports a numerically newer build:
 5. Ask Codex to perform static comparison, candidate discovery, code changes,
    documentation, and proprietary-binary-free tests in that clone.
 
+Every run receives a mode-0600 snapshot of
+[Automated Repair Agent Handoff](automated-repair-agent-handoff.md). It
+preserves the two validated host profiles, the separate phone/physical
+keyboard paths, failed pacing and routing hypotheses, direct-X11 acceptance,
+restart and descriptor lessons, action boundaries, and manual approval gates.
+The generated task context requires that snapshot and the detailed project
+notes to be read before editing.
+
 An installer wrapper that cannot be extracted is not executed automatically.
 The existing `--sandbox-install` path requires a deliberate operator action
 because it creates a root-managed transient sandbox. The repair context records
@@ -113,6 +128,7 @@ Each task stores these fields atomically with mode `0600`:
 - task kind, candidate identity, selected behavior track, and base commit
 - sanitized release metadata and static staging result
 - repair checkout and context paths
+- an operational-handoff snapshot with the two-host troubleshooting history
 - Codex thread UUID, attempt count, last event time, and phase
 - JSONL events, final structured result, and test output
 
@@ -132,6 +148,11 @@ then independently runs the full unit suite. Its terminal states are:
 | `ready-for-review` | Source changed and tests pass; semantic review and live acceptance remain |
 | `no-change` | Codex found no safe source change |
 | `blocked` | Evidence, staging, tests, or human approval is still required |
+
+If a service journal reports `failed to run command 'codex'`, rerun
+`configure-updater.sh enable`. Current configurations persist the absolute
+Codex executable, so NVM-only interactive `PATH` entries are not required by
+the user service.
 
 ## State and privacy
 

--- a/scripts/configure-updater.sh
+++ b/scripts/configure-updater.sh
@@ -10,6 +10,7 @@ state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/uu-remote-updater"
 unit_dir="$HOME/.config/systemd/user"
 model='codex-auto-review'
 reasoning_effort='medium'
+codex_executable=''
 track=''
 branch='main'
 idle_minutes=45
@@ -30,6 +31,7 @@ Enable options:
   --model MODEL          Codex model (default: codex-auto-review)
   --reasoning-effort EFFORT
                          Codex reasoning effort (default: medium)
+  --codex PATH           absolute Codex executable (default: current command)
   --idle-minutes N       documented maintenance idle window (default: 45)
   --no-auto-reinstall    restart and diagnose, but do not reinstall the track
 EOF
@@ -56,6 +58,10 @@ while (($#)); do
             ;;
         --reasoning-effort)
             reasoning_effort="${2:?--reasoning-effort requires a value}"
+            shift 2
+            ;;
+        --codex)
+            codex_executable="${2:?--codex requires a path}"
             shift 2
             ;;
         --idle-minutes)
@@ -109,12 +115,18 @@ case "$command" in
             printf 'UU updater repository is unavailable: %s\n' "$repo_dir" >&2
             exit 1
         fi
-        for required in codex git python3 systemctl; do
+        for required in git python3 systemctl; do
             if ! command -v "$required" >/dev/null 2>&1; then
                 printf 'missing updater dependency: %s\n' "$required" >&2
                 exit 1
             fi
         done
+        codex_executable="${codex_executable:-$(command -v codex || true)}"
+        if [[ -z "$codex_executable" || "$codex_executable" != /* ||
+              ! -x "$codex_executable" ]]; then
+            printf 'missing executable Codex path; use --codex /absolute/path/to/codex\n' >&2
+            exit 1
+        fi
         if ! [[ "$idle_minutes" =~ ^[0-9]+$ ]] || ((idle_minutes < 5)); then
             printf -- '--idle-minutes must be at least 5.\n' >&2
             exit 2
@@ -126,7 +138,7 @@ case "$command" in
             printf 'known-good track tag is unavailable: %s\n' "$track" >&2
             exit 1
         fi
-        if ! codex login status 2>&1 | grep -q '^Logged in'; then
+        if ! "$codex_executable" login status 2>&1 | grep -q '^Logged in'; then
             printf 'Codex is not logged in for this user. Run codex login first.\n' >&2
             exit 1
         fi
@@ -135,7 +147,7 @@ case "$command" in
         install -d -m 0755 "$HOME/.local/bin" "$unit_dir"
         python3 - "$config_file" "$repo_dir" "$state_dir" "$branch" \
             "$track" "$model" "$reasoning_effort" "$idle_minutes" \
-            "$auto_reinstall" <<'PY'
+            "$auto_reinstall" "$codex_executable" <<'PY'
 import json
 import os
 import sys
@@ -151,6 +163,7 @@ from pathlib import Path
     effort,
     idle_minutes,
     auto_reinstall,
+    codex_executable,
 ) = sys.argv[1:]
 value = {
     "schema_version": 1,
@@ -162,6 +175,7 @@ value = {
     "endpoint": "https://api.nrd.nie.163.com/api/v1/release/dl/1?channel=gwqd",
     "codex_model": model,
     "codex_reasoning_effort": effort,
+    "codex_executable": codex_executable,
     "codex_timeout_seconds": 5400,
     "codex_max_used_percent": 20,
     "idle_minutes": int(idle_minutes),

--- a/scripts/uu_update_manager.py
+++ b/scripts/uu_update_manager.py
@@ -169,10 +169,12 @@ def codex_budget_from_rate_limits(
     }
 
 
-def codex_rate_limits(timeout: int = 15) -> dict[str, Any]:
+def codex_rate_limits(
+    codex_executable: str | Path = "codex", timeout: int = 15
+) -> dict[str, Any]:
     try:
         process = subprocess.Popen(
-            ["codex", "app-server", "--stdio"],
+            [str(codex_executable), "app-server", "--stdio"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -250,6 +252,7 @@ class Config:
     branch: str
     track: str
     endpoint: str
+    codex_executable: Path
     codex_model: str
     codex_reasoning_effort: str
     codex_timeout_seconds: int
@@ -274,6 +277,18 @@ class Config:
         effort = str(raw.get("codex_reasoning_effort", "")).strip()
         if not model or not effort:
             raise UpdateError("the updater needs a Codex model and reasoning effort")
+        codex_value = str(raw.get("codex_executable", "")).strip()
+        codex_executable = Path(codex_value).expanduser()
+        if (
+            not codex_value
+            or not codex_executable.is_absolute()
+            or not codex_executable.is_file()
+            or not os.access(codex_executable, os.X_OK)
+        ):
+            raise UpdateError(
+                "the updater needs an absolute executable Codex path; "
+                "rerun configure-updater.sh enable"
+            )
         max_used_percent = int(raw.get("codex_max_used_percent", 20))
         if not 0 <= max_used_percent <= 100:
             raise UpdateError("codex_max_used_percent must be between 0 and 100")
@@ -285,6 +300,7 @@ class Config:
             branch=str(raw.get("branch", "main")),
             track=str(raw.get("track", "track-rdp-broker-20260724")),
             endpoint=str(raw.get("endpoint", DEFAULT_ENDPOINT)),
+            codex_executable=codex_executable,
             codex_model=model,
             codex_reasoning_effort=effort,
             codex_timeout_seconds=max(300, int(raw.get("codex_timeout_seconds", 5400))),
@@ -593,6 +609,14 @@ class Manager:
     def write_context(self, task: dict[str, Any], repair_repo: Path) -> Path:
         context_path = repair_repo / "build/automated-repair/CONTEXT.md"
         context_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        handoff_source = (
+            self.config.repository / "docs/automated-repair-agent-handoff.md"
+        )
+        handoff_snapshot = context_path.parent / "OPERATIONAL-HANDOFF.md"
+        if not handoff_source.is_file():
+            raise UpdateError(f"missing automated repair handoff: {handoff_source}")
+        shutil.copyfile(handoff_source, handoff_snapshot)
+        handoff_snapshot.chmod(0o600)
         details = task.get("details", {})
         lines = [
             "# Automated UU Repair Context",
@@ -624,8 +648,15 @@ class Manager:
             "  output ignored and uncommitted.",
             "- Run focused tests and the full proprietary-binary-free unit suite.",
             "",
-            "Read `docs/upstream-maintenance.md`, `docs/security.md`,",
-            "`docs/release-tracks.md`, and `docs/automatic-updates.md` before editing.",
+            "## Required operational memory",
+            "",
+            "Before editing, read `build/automated-repair/OPERATIONAL-HANDOFF.md`.",
+            "It preserves the two-host keyboard history, direct-X11 acceptance,",
+            "failed hypotheses, rollback rules, and the automated action contract.",
+            "Then read `docs/upstream-maintenance.md`, `docs/security.md`,",
+            "`docs/release-tracks.md`, `docs/automatic-updates.md`,",
+            "`docs/debugging-journey.md`, `docs/mobile-keyboard-parity-handoff.md`,",
+            "`docs/xrdp-and-keyboard-recovery.md`, and `docs/troubleshooting.md`.",
         ]
         context_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         context_path.chmod(0o600)
@@ -1166,7 +1197,14 @@ class Manager:
                 "CONTEXT.md, preserve existing work and test results, and finish the same "
                 "task. Keep every safety and review gate in that context."
             )
-            return ["codex", "exec", "resume", *common, str(task["thread_id"]), prompt]
+            return [
+                str(self.config.codex_executable),
+                "exec",
+                "resume",
+                *common,
+                str(task["thread_id"]),
+                prompt,
+            ]
         prompt = (
             "Handle the automated UU maintenance task described in "
             "build/automated-repair/CONTEXT.md end to end inside this checkout. "
@@ -1177,7 +1215,7 @@ class Manager:
             "manifest, touch the live installation, use sudo, commit, or push."
         )
         return [
-            "codex",
+            str(self.config.codex_executable),
             "exec",
             *common,
             "--sandbox",
@@ -1347,6 +1385,12 @@ class Manager:
             task["phase"] = "codex-model-reset"
         task["codex_model"] = self.config.codex_model
         task["codex_reasoning_effort"] = self.config.codex_reasoning_effort
+        repair_repo_value = task.get("repair_repo")
+        repair_repo = (
+            Path(str(repair_repo_value)) if repair_repo_value else None
+        )
+        if repair_repo is not None and repair_repo.is_dir():
+            task["context"] = str(self.write_context(task, repair_repo))
         self.save_task(task)
         next_retry = float(task.get("next_retry_epoch", 0))
         if next_retry > time.time():
@@ -1358,7 +1402,8 @@ class Manager:
             return
         try:
             budget = codex_budget_from_rate_limits(
-                codex_rate_limits(), self.config.codex_max_used_percent
+                codex_rate_limits(self.config.codex_executable),
+                self.config.codex_max_used_percent,
             )
         except UpdateError as error:
             budget = {

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -112,6 +112,20 @@ class DocumentationTests(unittest.TestCase):
         self.assertIn("does not prove", recovery)
         self.assertIn("never record a key code", recovery)
 
+    def test_automated_repair_handoff_preserves_two_host_history(self) -> None:
+        handoff = (
+            REPO_DIR / "docs/automated-repair-agent-handoff.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("OptiPlex-7090", handoff)
+        self.assertIn("Affected XRDP/Xorg workstation", handoff)
+        self.assertIn("52/52 transitions", handoff)
+        self.assertIn("route=x11-text", handoff)
+        self.assertIn("No replay after ambiguity", handoff)
+        self.assertRegex(
+            handoff, r"may not approve its own binary\s+interpretation"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -33,8 +33,9 @@ class UpdateManagerTests(unittest.TestCase):
             branch="main",
             track="track-rdp-broker-20260724",
             endpoint="https://example.invalid/latest?private=token",
-            codex_model="gpt-5.6-sol",
-            codex_reasoning_effort="xhigh",
+            codex_executable=Path("/opt/codex/bin/codex"),
+            codex_model="codex-auto-review",
+            codex_reasoning_effort="medium",
             codex_timeout_seconds=5400,
             codex_max_used_percent=20,
             idle_minutes=45,
@@ -100,13 +101,15 @@ class UpdateManagerTests(unittest.TestCase):
                     "id": "model-change",
                     "attempts": 0,
                     "thread_id": "old-thread",
-                    "codex_model": "codex-auto-review",
-                    "codex_reasoning_effort": "medium",
+                    "codex_model": "gpt-5.6-sol",
+                    "codex_reasoning_effort": "xhigh",
                 }
             )
             manager.monitor()
             self.assertIsNone(manager.assertion["thread_id"])
-            self.assertEqual("gpt-5.6-sol", manager.assertion["codex_model"])
+            self.assertEqual(
+                "codex-auto-review", manager.assertion["codex_model"]
+            )
 
     def test_release_version_prefers_full_build_identifier(self) -> None:
         self.assertEqual(
@@ -249,15 +252,72 @@ class UpdateManagerTests(unittest.TestCase):
                 "thread_id": None,
             }
             initial = manager.codex_command(task, resume=False)
-            self.assertIn("gpt-5.6-sol", initial)
-            self.assertIn('model_reasoning_effort="xhigh"', initial)
+            self.assertEqual("/opt/codex/bin/codex", initial[0])
+            self.assertIn("codex-auto-review", initial)
+            self.assertIn('model_reasoning_effort="medium"', initial)
             self.assertIn("workspace-write", initial)
             self.assertNotIn("--dangerously-bypass-approvals-and-sandbox", initial)
 
             task["thread_id"] = "019f89b6-dd9d-7f11-98ef-0e7501fcae3c"
             resumed = manager.codex_command(task, resume=True)
-            self.assertEqual(["codex", "exec", "resume"], resumed[:3])
+            self.assertEqual(
+                ["/opt/codex/bin/codex", "exec", "resume"], resumed[:3]
+            )
             self.assertIn(task["thread_id"], resumed)
+
+    def test_config_requires_and_preserves_absolute_codex_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            config_path = root / "updater.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "repository": str(REPO_DIR),
+                        "state_dir": str(root / "state"),
+                        "remote": "origin",
+                        "branch": "main",
+                        "track": "track-direct-x11-20260724",
+                        "endpoint": "https://example.invalid/latest",
+                        "codex_executable": "/bin/true",
+                        "codex_model": "codex-auto-review",
+                        "codex_reasoning_effort": "medium",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            config = Config.read(config_path)
+            self.assertEqual(Path("/bin/true"), config.codex_executable)
+            self.assertEqual("codex-auto-review", config.codex_model)
+            self.assertEqual("medium", config.codex_reasoning_effort)
+
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            raw.pop("codex_executable")
+            config_path.write_text(json.dumps(raw), encoding="utf-8")
+            with self.assertRaisesRegex(
+                Exception, "absolute executable Codex path"
+            ):
+                Config.read(config_path)
+
+    def test_repair_context_snapshots_complete_operational_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manager = Manager(self.config(root / "state"))
+            repair_repo = root / "repair"
+            repair_repo.mkdir()
+            task = {
+                "id": "upstream-release-fixture",
+                "kind": "upstream-release",
+                "created_at": "2026-07-24T00:00:00+00:00",
+                "base_commit": "fixture-base",
+                "details": {"version": "4.34.0.8979"},
+            }
+            context = manager.write_context(task, repair_repo)
+            handoff = context.parent / "OPERATIONAL-HANDOFF.md"
+            self.assertTrue(handoff.is_file())
+            self.assertIn("The Two Validated Host Profiles", handoff.read_text())
+            self.assertIn("OPERATIONAL-HANDOFF.md", context.read_text())
+            self.assertIn("mobile-keyboard-parity-handoff.md", context.read_text())
 
     def test_systemd_timers_survive_boot_without_touching_the_bridge(self) -> None:
         daily = (REPO_DIR / "systemd/uu-remote-update-check.timer").read_text()
@@ -275,7 +335,11 @@ class UpdateManagerTests(unittest.TestCase):
         configurator = (REPO_DIR / "scripts/configure-updater.sh").read_text()
         self.assertIn("--automatic-updates", installer)
         self.assertIn('configure-updater.sh" enable', installer)
-        self.assertIn("codex login status 2>&1", configurator)
+        self.assertIn('"$codex_executable" login status 2>&1', configurator)
+        self.assertIn('"codex_executable": codex_executable', configurator)
+        self.assertIn("--codex PATH", configurator)
+        self.assertIn("model='codex-auto-review'", configurator)
+        self.assertIn("reasoning_effort='medium'", configurator)
         self.assertIn('scripts/uu-remote"', configurator)
         self.assertIn("track-direct-x11-20260724", configurator)
         self.assertIn("track-rdp-broker-20260724", configurator)


### PR DESCRIPTION
## Summary
- persist the absolute Codex executable so NVM installations work from systemd user services
- default and validate codex-auto-review with medium reasoning
- snapshot the complete two-host keyboard and troubleshooting handoff into every repair checkout
- refresh task context before new or resumed Codex attempts

## Validation
- 56 Python unit and documentation tests passed
- shell entrypoints pass bash -n
- Python sources pass py_compile
- git diff --check passed