### PR TITLE
Harden updater workspace retry gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ locked by the release manifest.
   installations remain reachable from the smaller systemd user-service `PATH`
 - snapshot the complete two-host keyboard and troubleshooting handoff into
   every repair checkout before starting or resuming Codex
+- preflight the Ubuntu Bubblewrap/AppArmor path before spending a Codex
+  attempt, retain repair evidence across an explicit retry, and keep
+  `workspace-write` instead of bypassing the sandbox
+- record an explicit non-promotion result for every automated repair so a
+  completed source patch cannot transfer into the live UU prefix before
+  semantic review and controller acceptance
+- document the recurring Wine `devcon` connection stall and its reversible
+  live mitigation as evidence for a permanent rollback-safe fix
 
 - wait for the actual FreeRDP relay window after Wine's short-lived Unix
   launcher exits, verify that the spawned GNOME daemon owns its configured

--- a/docs/automated-repair-agent-handoff.md
+++ b/docs/automated-repair-agent-handoff.md
@@ -123,6 +123,17 @@ Preserve these decisions:
 12. **Logs are privacy-bounded:** routine logging stops after quotas and never
     records keycodes or typed content. A quiet bounded log is not proof that an
     input API was never called.
+13. **Wine driver installation can block connection setup:** on the affected
+    workstation, a controller retry still reached UU's `devcon.exe` path even
+    with the approved 4.33 server patches. Each unsupported `gvinput`/HID
+    install consumed one CPU and delayed setup by roughly 84–218 seconds.
+    Reversibly making only `devcon.exe` unavailable reduced the same input-init
+    boundary to roughly 0.8–1.1 seconds. Treat this as strong evidence for a
+    permanent, rollback-safe suppression of the Windows kernel-driver path,
+    not as permission to delete the original executable or blindly copy the
+    workaround to an unknown release. The relay session in this observation
+    was cross-region, but its recorded input-delay counters were not the cause
+    of this setup stall.
 
 The chronological evidence is in
 [Debugging Journey](debugging-journey.md), and the reusable investigation

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -167,6 +167,30 @@ disabled Git push URL in the repair clone. Network access remains available
 because Codex authentication requires it. These controls reduce accidental
 reach; they are not a security boundary equivalent to a separate VM.
 
+On Ubuntu 24.04, `workspace-write` also needs Ubuntu's AppArmor profile for
+Bubblewrap. If status reports `codex-sandbox-deferred`, install and enable only
+the distro profile rather than disabling unprivileged-user-namespace
+restrictions globally:
+
+```bash
+sudo apt install apparmor-profiles
+sudo install -o root -g root -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+uu-remote update retry
+```
+
+`retry` keeps the private evidence and repair checkout, clears the unusable
+Codex thread, and starts a new thread on the next monitor run. It refuses
+non-retryable phases.
+
+There is deliberately no automatic transfer from `ready-for-review` into the
+live Wine prefix. The task record always marks automated output as ineligible
+for live promotion. A new patch must finish static work and tests, receive
+independent semantic binary review, be marked approved by a maintainer, and
+pass controller acceptance before the normal installer may transfer it.
+
 ## Another-computer handoff
 
 Send the operator this sequence after choosing the track from

--- a/scripts/uu_update_manager.py
+++ b/scripts/uu_update_manager.py
@@ -28,6 +28,13 @@ DEFAULT_ENDPOINT = "https://api.nrd.nie.163.com/api/v1/release/dl/1?channel=gwqd
 VERSION_RE = re.compile(r"(?<!\d)(\d+(?:\.\d+){2,3})(?!\d)")
 TASK_ID_RE = re.compile(r"[^A-Za-z0-9._-]+")
 TERMINAL_PHASES = {"blocked", "no-change", "ready-for-review"}
+RETRYABLE_PHASES = {
+    "blocked",
+    "codex-budget-deferred",
+    "codex-interrupted",
+    "codex-sandbox-deferred",
+    "repair-waiting",
+}
 
 
 class UpdateError(RuntimeError):
@@ -125,6 +132,38 @@ def command_output(
         detail = result.stderr.strip() or result.stdout.strip() or "no output"
         raise UpdateError(f"command failed ({' '.join(command)}): {detail[-1200:]}")
     return result
+
+
+def workspace_sandbox_probe() -> dict[str, Any]:
+    """Prove that Codex's Bubblewrap user namespace can start on this host."""
+    bwrap = Path("/usr/bin/bwrap")
+    if not bwrap.is_file() or not os.access(bwrap, os.X_OK):
+        return {
+            "available": False,
+            "detail": "bubblewrap is unavailable at /usr/bin/bwrap",
+        }
+    result = command_output(
+        [
+            str(bwrap),
+            "--die-with-parent",
+            "--unshare-user",
+            "--uid",
+            "0",
+            "--gid",
+            "0",
+            "--ro-bind",
+            "/",
+            "/",
+            "/bin/true",
+        ],
+        timeout=15,
+    )
+    detail = (result.stderr.strip() or result.stdout.strip())[-1200:]
+    return {
+        "available": result.returncode == 0,
+        "returncode": result.returncode,
+        "detail": detail,
+    }
 
 
 def codex_budget_from_rate_limits(
@@ -1168,6 +1207,47 @@ class Manager:
             return None
         return load_json(self.pending_path)
 
+    def retry_task(self) -> None:
+        task = self.load_pending()
+        if task is None:
+            status = load_json(self.status_path, default={})
+            task_id = str(status.get("active_task", "")).strip()
+            if not task_id:
+                raise UpdateError("there is no retained UU repair task to retry")
+            task_path = self.tasks_dir / task_name(task_id) / "task.json"
+            if not task_path.is_file():
+                raise UpdateError(f"retained UU repair task is unavailable: {task_id}")
+            task = load_json(task_path)
+
+        phase = str(task.get("phase", ""))
+        if phase not in RETRYABLE_PHASES:
+            raise UpdateError(
+                f"UU repair task {task.get('id', 'unknown')} cannot be retried "
+                f"from phase {phase or 'unknown'}"
+            )
+
+        task["phase"] = "queued"
+        task["thread_id"] = None
+        task["retry_count"] = int(task.get("retry_count", 0)) + 1
+        task["manually_retried_at"] = utc_now()
+        for key in (
+            "completed_at",
+            "last_returncode",
+            "next_retry_epoch",
+            "result",
+            "verification",
+        ):
+            task.pop(key, None)
+        self.save_task(task)
+        self.write_status(
+            "repair-queued",
+            active_task=task["id"],
+            message=(
+                "the retained repair evidence and checkout will be retried "
+                "in a new Codex thread"
+            ),
+        )
+
     def save_task(self, task: dict[str, Any]) -> None:
         task["updated_at"] = utc_now()
         task_dir = self.tasks_dir / str(task["id"])
@@ -1367,6 +1447,14 @@ class Manager:
         task["phase"] = phase
         task["result"] = result
         task["verification"] = verification
+        task["live_promotion"] = {
+            "eligible": False,
+            "reason": (
+                "automated Codex output never authorizes transfer to the live "
+                "UU prefix; semantic binary review and controller acceptance "
+                "must finish first"
+            ),
+        }
         task["completed_at"] = utc_now()
         atomic_json(self.tasks_dir / str(task["id"]) / "task.json", task)
         self.pending_path.unlink(missing_ok=True)
@@ -1400,6 +1488,25 @@ class Manager:
                 next_retry_at=datetime.fromtimestamp(next_retry, timezone.utc).isoformat(),
             )
             return
+        sandbox = workspace_sandbox_probe()
+        if not sandbox["available"]:
+            retry = time.time() + 3600
+            task["phase"] = "codex-sandbox-deferred"
+            task["workspace_sandbox"] = sandbox
+            task["next_retry_epoch"] = retry
+            self.save_task(task)
+            self.write_status(
+                "codex-sandbox-deferred",
+                active_task=task["id"],
+                message=(
+                    "Codex workspace-write could not start. On Ubuntu, enable "
+                    "the distro bwrap-userns-restrict AppArmor profile."
+                ),
+                workspace_sandbox=sandbox,
+                next_retry_at=datetime.fromtimestamp(retry, timezone.utc).isoformat(),
+            )
+            return
+        task["workspace_sandbox"] = sandbox
         try:
             budget = codex_budget_from_rate_limits(
                 codex_rate_limits(self.config.codex_executable),
@@ -1485,7 +1592,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path.home() / ".config/uu-remote-bridge/updater.json",
     )
-    parser.add_argument("command", choices=("check", "monitor", "status"))
+    parser.add_argument("command", choices=("check", "monitor", "retry", "status"))
     return parser.parse_args()
 
 
@@ -1500,6 +1607,8 @@ def main() -> int:
         with manager.lock():
             if args.command == "check":
                 manager.check()
+            elif args.command == "retry":
+                manager.retry_task()
             else:
                 manager.monitor()
         return 0

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -94,6 +94,9 @@ class UpdateManagerTests(unittest.TestCase):
             return_value={
                 "rateLimitsByLimitId": {"codex": {"primary": {"usedPercent": 1}}}
             },
+        ), patch(
+            "uu_update_manager.workspace_sandbox_probe",
+            return_value={"available": True, "returncode": 0, "detail": ""},
         ):
             manager = ModelChangeManager(self.config(Path(temporary)))
             manager.save_task(
@@ -110,6 +113,32 @@ class UpdateManagerTests(unittest.TestCase):
             self.assertEqual(
                 "codex-auto-review", manager.assertion["codex_model"]
             )
+
+    def test_monitor_defers_before_codex_when_workspace_sandbox_is_unavailable(
+        self,
+    ) -> None:
+        class DeferredManager(Manager):
+            def run_codex(self, task):
+                raise AssertionError("Codex must not run without workspace-write")
+
+        with tempfile.TemporaryDirectory() as temporary, patch(
+            "uu_update_manager.workspace_sandbox_probe",
+            return_value={
+                "available": False,
+                "returncode": 1,
+                "detail": "No permissions to create new namespace",
+            },
+        ), patch(
+            "uu_update_manager.codex_rate_limits",
+            side_effect=AssertionError("budget query must follow sandbox preflight"),
+        ):
+            manager = DeferredManager(self.config(Path(temporary)))
+            manager.save_task({"id": "sandbox-deferred", "attempts": 0})
+            manager.monitor()
+            task = json.loads(manager.pending_path.read_text(encoding="utf-8"))
+            self.assertEqual("codex-sandbox-deferred", task["phase"])
+            self.assertEqual(0, task["attempts"])
+            self.assertIn("namespace", task["workspace_sandbox"]["detail"])
 
     def test_release_version_prefers_full_build_identifier(self) -> None:
         self.assertEqual(
@@ -264,6 +293,61 @@ class UpdateManagerTests(unittest.TestCase):
                 ["/opt/codex/bin/codex", "exec", "resume"], resumed[:3]
             )
             self.assertIn(task["thread_id"], resumed)
+
+    def test_retry_requeues_a_blocked_task_without_deleting_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manager = Manager(self.config(root))
+            task_dir = manager.tasks_dir / "blocked-fixture"
+            task_dir.mkdir(parents=True)
+            evidence = task_dir / "codex-events.jsonl"
+            evidence.write_text('{"type":"fixture"}\n', encoding="utf-8")
+            task = {
+                "schema_version": 1,
+                "id": "blocked-fixture",
+                "phase": "blocked",
+                "attempts": 1,
+                "thread_id": "old-thread",
+                "result": {"status": "blocked"},
+                "verification": {"tests_passed": True},
+                "completed_at": "2026-07-24T00:00:00+00:00",
+            }
+            (task_dir / "task.json").write_text(json.dumps(task), encoding="utf-8")
+            manager.write_status("blocked", active_task=task["id"])
+
+            manager.retry_task()
+
+            queued = json.loads(manager.pending_path.read_text(encoding="utf-8"))
+            self.assertEqual("queued", queued["phase"])
+            self.assertIsNone(queued["thread_id"])
+            self.assertEqual(1, queued["attempts"])
+            self.assertEqual(1, queued["retry_count"])
+            self.assertNotIn("result", queued)
+            self.assertNotIn("verification", queued)
+            self.assertEqual('{"type":"fixture"}\n', evidence.read_text())
+
+    def test_ready_for_review_is_never_eligible_for_live_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manager = Manager(self.config(root))
+            task_dir = manager.tasks_dir / "review-fixture"
+            task_dir.mkdir(parents=True)
+            task = {"id": "review-fixture"}
+            with patch.object(
+                manager,
+                "verify_repair",
+                return_value={
+                    "changed": True,
+                    "tests_passed": True,
+                    "safety_violations": [],
+                },
+            ):
+                manager.finish_task(task, {"status": "ready_for_review"})
+            retained = json.loads(
+                (task_dir / "task.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("ready-for-review", retained["phase"])
+            self.assertFalse(retained["live_promotion"]["eligible"])
 
     def test_config_requires_and_preserves_absolute_codex_executable(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -74,6 +74,9 @@ class UpdateManagerTests(unittest.TestCase):
                 },
                 "credits": {"hasCredits": True, "balance": "9999"},
             },
+        ), patch(
+            "uu_update_manager.workspace_sandbox_probe",
+            return_value={"available": True, "returncode": 0, "detail": ""},
         ):
             manager = DeferredManager(self.config(Path(temporary)))
             manager.save_task({"id": "deferred", "attempts": 0})


### PR DESCRIPTION
Enables an explicit retained-task retry after a Codex sandbox failure, preflights Ubuntu Bubblewrap before spending an attempt, preserves workspace-write, records automated output as ineligible for live promotion, and adds the latest two-host/devcon troubleshooting evidence. All 59 tests pass.