### PR TITLE
Prevent false UU live recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ locked by the release manifest.
   semantic review and controller acceptance
 - document the recurring Wine `devcon` connection stall and its reversible
   live mitigation as evidence for a permanent rollback-safe fix
+- query the persistent user-manager bus, accept any matching GNOME RDP process
+  that actually owns the listener, and distinguish a recent restart storm from
+  an old cumulative restart count
+- make known-good live reinstallation opt-in and refuse live recovery when the
+  service-manager probe itself is indeterminate
+- import operator-authorized networkless staging on retry only after checking
+  its method and all recorded binary hashes
 
 - wait for the actual FreeRDP relay window after Wine's short-lived Unix
   launcher exits, verify that the spawned GNOME daemon owns its configured

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -81,11 +81,14 @@ and ignored. This matters because a release channel can temporarily advertise
 an older build. A different filename alone is not treated as an upgrade.
 
 The monitor changes the live relay only after health is bad twice, 20 seconds
-apart. It then performs one systemd restart. If that fails and known-good
-reinstallation is enabled, it first clones the selected immutable track, runs
-the repository tests, and prebuilds compatibility artifacts while the already
-unhealthy relay remains untouched. Only the final reinstall reaches the live
-prefix. A healthy bridge is never periodically restarted for maintenance.
+apart. An indeterminate user-manager query is recorded for repair and never
+treated as permission to restart. A confirmed failure permits one systemd
+restart. Known-good reinstallation is disabled by default; an operator must
+deliberately pass `--auto-reinstall` when configuring the updater. When opted
+in, it first clones the selected immutable track, runs the repository tests,
+and prebuilds compatibility artifacts while the already unhealthy relay
+remains untouched. Only the final reinstall reaches the live prefix. A healthy
+bridge is never periodically restarted for maintenance.
 
 ## New upstream release workflow
 
@@ -183,7 +186,9 @@ uu-remote update retry
 
 `retry` keeps the private evidence and repair checkout, clears the unusable
 Codex thread, and starts a new thread on the next monitor run. It refuses
-non-retryable phases.
+non-retryable phases. If an operator has completed the documented networkless
+fallback in the task's `stage-sandbox` directory, retry imports it only after
+the installer, server, and health-monitor hashes match the sandbox record.
 
 There is deliberately no automatic transfer from `ready-for-review` into the
 live Wine prefix. The task record always marks automated output as ineligible

--- a/scripts/configure-updater.sh
+++ b/scripts/configure-updater.sh
@@ -14,7 +14,7 @@ codex_executable=''
 track=''
 branch='main'
 idle_minutes=45
-auto_reinstall=true
+auto_reinstall=false
 command="${1:-status}"
 [[ $# -eq 0 ]] || shift
 
@@ -33,7 +33,9 @@ Enable options:
                          Codex reasoning effort (default: medium)
   --codex PATH           absolute Codex executable (default: current command)
   --idle-minutes N       documented maintenance idle window (default: 45)
-  --no-auto-reinstall    restart and diagnose, but do not reinstall the track
+  --auto-reinstall       opt in to reinstalling the known-good track after a
+                         confirmed restart failure (default: disabled)
+  --no-auto-reinstall    retain the safe default; accepted for compatibility
 EOF
 }
 
@@ -70,6 +72,10 @@ while (($#)); do
             ;;
         --no-auto-reinstall)
             auto_reinstall=false
+            shift
+            ;;
+        --auto-reinstall)
+            auto_reinstall=true
             shift
             ;;
         --purge-state)

--- a/scripts/uu_update_manager.py
+++ b/scripts/uu_update_manager.py
@@ -134,6 +134,18 @@ def command_output(
     return result
 
 
+def systemctl_user_command(*arguments: str) -> list[str]:
+    """Address the persistent user manager instead of an RDP session bus."""
+    runtime_dir = Path(f"/run/user/{os.getuid()}")
+    return [
+        "/usr/bin/env",
+        f"DBUS_SESSION_BUS_ADDRESS=unix:path={runtime_dir}/bus",
+        "/usr/bin/systemctl",
+        "--user",
+        *arguments,
+    ]
+
+
 def workspace_sandbox_probe() -> dict[str, Any]:
     """Prove that Codex's Bubblewrap user namespace can start on this host."""
     bwrap = Path("/usr/bin/bwrap")
@@ -345,7 +357,7 @@ class Config:
             codex_timeout_seconds=max(300, int(raw.get("codex_timeout_seconds", 5400))),
             codex_max_used_percent=max_used_percent,
             idle_minutes=max(5, int(raw.get("idle_minutes", 45))),
-            auto_reinstall_known_good=bool(raw.get("auto_reinstall_known_good", True)),
+            auto_reinstall_known_good=bool(raw.get("auto_reinstall_known_good", False)),
             max_download_bytes=max(
                 1024 * 1024,
                 int(raw.get("max_download_bytes", 1024 * 1024 * 1024)),
@@ -863,14 +875,13 @@ class Manager:
     def health(self) -> dict[str, Any]:
         issues: list[str] = []
         service = command_output(
-            [
-                "systemctl",
-                "--user",
+            systemctl_user_command(
                 "show",
                 "uu-remote-bridge.service",
                 "--property=ActiveState",
                 "--property=NRestarts",
-            ],
+                "--property=ActiveEnterTimestampMonotonic",
+            ),
             timeout=15,
         )
         service_properties = dict(
@@ -878,13 +889,27 @@ class Manager:
             for line in service.stdout.splitlines()
             if "=" in line
         )
-        if service_properties.get("ActiveState") != "active":
+        if service.returncode != 0:
+            issues.append("bridge-service-query-failed")
+        elif service_properties.get("ActiveState") != "active":
             issues.append("bridge-service-inactive")
         try:
             restart_count = int(service_properties.get("NRestarts", "0"))
         except ValueError:
             restart_count = 0
-        if restart_count >= 3:
+        try:
+            active_since = (
+                int(service_properties.get("ActiveEnterTimestampMonotonic", "0"))
+                / 1_000_000
+            )
+        except ValueError:
+            active_since = 0
+        active_age_seconds = (
+            max(0.0, time.monotonic() - active_since) if active_since else None
+        )
+        if restart_count >= 3 and (
+            active_age_seconds is None or active_age_seconds <= 15 * 60
+        ):
             issues.append("bridge-restart-storm")
         for label, pattern in (
             ("uu-server-missing", r"GameViewerServer\.exe"),
@@ -907,7 +932,6 @@ class Manager:
         relay = command_output(
             [
                 "pgrep",
-                "-o",
                 "-u",
                 str(os.getuid()),
                 "-f",
@@ -915,14 +939,18 @@ class Manager:
             ],
             timeout=15,
         )
-        relay_pid = relay.stdout.strip()
-        if relay.returncode != 0 or not relay_pid.isdigit():
+        relay_pids = {
+            line.strip()
+            for line in relay.stdout.splitlines()
+            if line.strip().isdigit()
+        }
+        if relay.returncode != 0 or not relay_pids:
             issues.append("gnome-rdp-relay-missing")
         else:
             listener = command_output(
                 ["ss", "-H", "-ltnp", f"sport = :{rdp_port}"], timeout=15
             )
-            if f"pid={relay_pid}," not in listener.stdout:
+            if not any(f"pid={pid}," in listener.stdout for pid in relay_pids):
                 issues.append("rdp-listener-owner-mismatch")
 
         manifest = (
@@ -936,12 +964,13 @@ class Manager:
             "healthy": not issues,
             "issues": issues,
             "restart_count": restart_count,
+            "active_age_seconds": active_age_seconds,
             "rdp_port": int(rdp_port),
         }
 
     def restart_bridge(self) -> dict[str, Any]:
         result = command_output(
-            ["systemctl", "--user", "restart", "uu-remote-bridge.service"],
+            systemctl_user_command("restart", "uu-remote-bridge.service"),
             timeout=90,
         )
         for _ in range(24):
@@ -1113,7 +1142,7 @@ class Manager:
         if not isinstance(entries, list):
             raise UpdateError("runtime rollback snapshot is malformed")
         command_output(
-            ["systemctl", "--user", "stop", "uu-remote-bridge.service"], timeout=90
+            systemctl_user_command("stop", "uu-remote-bridge.service"), timeout=90
         )
         home = Path.home().resolve()
         for entry in entries:
@@ -1126,9 +1155,9 @@ class Manager:
             self.remove_snapshot_item(destination)
             if entry.get("existed") is True:
                 self.copy_snapshot_item(snapshot / "files" / relative, destination)
-        command_output(["systemctl", "--user", "daemon-reload"], timeout=30)
+        command_output(systemctl_user_command("daemon-reload"), timeout=30)
         start = command_output(
-            ["systemctl", "--user", "start", "uu-remote-bridge.service"], timeout=90
+            systemctl_user_command("start", "uu-remote-bridge.service"), timeout=90
         )
         for _ in range(24):
             health = self.health()
@@ -1174,6 +1203,15 @@ class Manager:
         if confirmed["healthy"]:
             self.write_status("healthy", bridge_health=confirmed, message="transient issue cleared")
             return
+        if "bridge-service-query-failed" in confirmed["issues"]:
+            details = self.runtime_context(first, confirmed)
+            details["known_good_reinstall"] = {
+                "attempted": False,
+                "reason": "the service-manager probe was indeterminate",
+            }
+            identity = datetime.now().strftime("%Y%m%d-%H%M")
+            self.queue_task("runtime-health", identity, details)
+            return
         restarted = self.restart_bridge()
         if restarted["health"]["healthy"]:
             self.write_status(
@@ -1207,6 +1245,48 @@ class Manager:
             return None
         return load_json(self.pending_path)
 
+    def refresh_operator_staging(self, task: dict[str, Any]) -> None:
+        if task.get("kind") != "upstream-release":
+            return
+        task_dir = self.tasks_dir / str(task["id"])
+        stage_dir = task_dir / "stage-sandbox"
+        record_path = stage_dir / "SHA256"
+        server = stage_dir / "GameViewerServer.exe"
+        healthd = stage_dir / "GameViewerHealthd.exe"
+        if not stage_dir.exists():
+            return
+        if not all(path.is_file() for path in (record_path, server, healthd)):
+            raise UpdateError(
+                f"operator staging is incomplete for task {task['id']}"
+            )
+        record = dict(
+            line.split("=", 1)
+            for line in record_path.read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+        observed = task.get("details", {}).get("observed_release", {})
+        expected_installer = str(observed.get("installer_sha256", ""))
+        if (
+            record.get("staging_method") != "systemd-sandbox"
+            or not re.fullmatch(r"[0-9a-f]{64}", expected_installer)
+            or record.get("installer_sha256") != expected_installer
+            or record.get("server_sha256") != sha256_file(server)
+            or record.get("healthd_sha256") != sha256_file(healthd)
+        ):
+            raise UpdateError(
+                f"operator staging failed hash or sandbox validation for {task['id']}"
+            )
+        task["details"]["staging"] = {
+            "returncode": 0,
+            "stage_dir": str(stage_dir),
+            "server_available": True,
+            "healthd_available": True,
+            "server_sha256": record["server_sha256"],
+            "healthd_sha256": record["healthd_sha256"],
+            "sandbox_executed": True,
+            "operator_authorized": True,
+        }
+
     def retry_task(self) -> None:
         task = self.load_pending()
         if task is None:
@@ -1230,6 +1310,7 @@ class Manager:
         task["thread_id"] = None
         task["retry_count"] = int(task.get("retry_count", 0)) + 1
         task["manually_retried_at"] = utc_now()
+        self.refresh_operator_staging(task)
         for key in (
             "completed_at",
             "last_returncode",

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -329,6 +330,58 @@ class UpdateManagerTests(unittest.TestCase):
             self.assertNotIn("verification", queued)
             self.assertEqual('{"type":"fixture"}\n', evidence.read_text())
 
+    def test_retry_imports_only_hash_verified_networkless_operator_staging(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manager = Manager(self.config(root))
+            task_dir = manager.tasks_dir / "staged-fixture"
+            stage = task_dir / "stage-sandbox"
+            stage.mkdir(parents=True)
+            server = stage / "GameViewerServer.exe"
+            healthd = stage / "GameViewerHealthd.exe"
+            server.write_bytes(b"server fixture")
+            healthd.write_bytes(b"health fixture")
+            installer_hash = hashlib.sha256(b"installer fixture").hexdigest()
+            server_hash = hashlib.sha256(server.read_bytes()).hexdigest()
+            healthd_hash = hashlib.sha256(healthd.read_bytes()).hexdigest()
+            (stage / "SHA256").write_text(
+                "\n".join(
+                    (
+                        f"installer_sha256={installer_hash}",
+                        f"server_sha256={server_hash}",
+                        f"healthd_sha256={healthd_hash}",
+                        "staging_method=systemd-sandbox",
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            task = {
+                "schema_version": 1,
+                "id": "staged-fixture",
+                "kind": "upstream-release",
+                "phase": "blocked",
+                "attempts": 1,
+                "thread_id": "old-thread",
+                "details": {
+                    "observed_release": {"installer_sha256": installer_hash},
+                    "staging": {"returncode": 1},
+                },
+            }
+            (task_dir / "task.json").write_text(json.dumps(task), encoding="utf-8")
+            manager.write_status("blocked", active_task=task["id"])
+
+            manager.retry_task()
+
+            queued = json.loads(manager.pending_path.read_text(encoding="utf-8"))
+            staging = queued["details"]["staging"]
+            self.assertTrue(staging["sandbox_executed"])
+            self.assertTrue(staging["operator_authorized"])
+            self.assertEqual(server_hash, staging["server_sha256"])
+            self.assertEqual(healthd_hash, staging["healthd_sha256"])
+
     def test_ready_for_review_is_never_eligible_for_live_promotion(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -377,6 +430,7 @@ class UpdateManagerTests(unittest.TestCase):
             self.assertEqual(Path("/bin/true"), config.codex_executable)
             self.assertEqual("codex-auto-review", config.codex_model)
             self.assertEqual("medium", config.codex_reasoning_effort)
+            self.assertFalse(config.auto_reinstall_known_good)
 
             raw = json.loads(config_path.read_text(encoding="utf-8"))
             raw.pop("codex_executable")
@@ -427,6 +481,8 @@ class UpdateManagerTests(unittest.TestCase):
         self.assertIn("--codex PATH", configurator)
         self.assertIn("model='codex-auto-review'", configurator)
         self.assertIn("reasoning_effort='medium'", configurator)
+        self.assertIn("auto_reinstall=false", configurator)
+        self.assertIn("--auto-reinstall", configurator)
         self.assertIn('scripts/uu-remote"', configurator)
         self.assertIn("track-direct-x11-20260724", configurator)
         self.assertIn("track-rdp-broker-20260724", configurator)
@@ -466,6 +522,96 @@ class UpdateManagerTests(unittest.TestCase):
             self.assertIn("rdp-listener-owner-mismatch", health["issues"])
             self.assertEqual(64, health["restart_count"])
             self.assertEqual(3391, health["rdp_port"])
+
+    def test_health_accepts_the_real_listener_among_old_relay_processes(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            home = root / "home"
+            manifest = (
+                home
+                / ".local/share/wineprefixes/uu-remote/compat/release-manifest.json"
+            )
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text("{}\n", encoding="utf-8")
+            responses = [
+                subprocess.CompletedProcess(
+                    [],
+                    0,
+                    (
+                        "ActiveState=active\n"
+                        "NRestarts=3\n"
+                        "ActiveEnterTimestampMonotonic=1000000000\n"
+                    ),
+                    "",
+                ),
+                subprocess.CompletedProcess([], 0, "101\n", ""),
+                subprocess.CompletedProcess([], 0, "102\n", ""),
+                subprocess.CompletedProcess([], 0, "10\n20\n", ""),
+                subprocess.CompletedProcess(
+                    [],
+                    0,
+                    'LISTEN 0 10 *:3390 *:* users:(("gnome-remote-de",pid=20,fd=15))\n',
+                    "",
+                ),
+            ]
+
+            with patch.object(Path, "home", return_value=home), patch(
+                "uu_update_manager.command_output", side_effect=responses
+            ) as output, patch(
+                "uu_update_manager.time.monotonic", return_value=10_000
+            ):
+                health = Manager(self.config(root / "state")).health()
+
+            self.assertTrue(health["healthy"])
+            self.assertNotIn("bridge-restart-storm", health["issues"])
+            self.assertGreater(health["active_age_seconds"], 15 * 60)
+            first_command = output.call_args_list[0].args[0]
+            self.assertIn(
+                "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/"
+                f"{os.getuid()}/bus",
+                first_command,
+            )
+
+    def test_indeterminate_service_probe_never_restarts_or_reinstalls(self) -> None:
+        class IndeterminateManager(Manager):
+            def __init__(self, config):
+                super().__init__(config)
+                self.health_results = iter(
+                    (
+                        {"healthy": False, "issues": ["bridge-service-query-failed"]},
+                        {"healthy": False, "issues": ["bridge-service-query-failed"]},
+                    )
+                )
+                self.queued = None
+
+            def health(self):
+                return next(self.health_results)
+
+            def restart_bridge(self):
+                raise AssertionError("an indeterminate probe must not restart UU")
+
+            def reinstall_known_good(self):
+                raise AssertionError("an indeterminate probe must not reinstall UU")
+
+            def runtime_context(self, first, after):
+                return {"initial_health": first, "health_after_restart": after}
+
+            def queue_task(self, kind, identity, details):
+                self.queued = (kind, identity, details)
+                return {}
+
+        with tempfile.TemporaryDirectory() as temporary, patch(
+            "uu_update_manager.time.sleep", return_value=None
+        ):
+            manager = IndeterminateManager(self.config(Path(temporary)))
+            manager.monitor_health()
+            self.assertIsNotNone(manager.queued)
+            self.assertEqual("runtime-health", manager.queued[0])
+            self.assertFalse(
+                manager.queued[2]["known_good_reinstall"]["attempted"]
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes stale GNOME RDP PID matching and cumulative restart-storm detection, pins health actions to the persistent user manager bus, makes known-good live reinstall opt-in, blocks recovery on indeterminate service queries, and hash-validates operator-authorized networkless staging before a repair retry. All 62 tests pass.