### PR TITLE
Fix updater workspace-write under Ubuntu AppArmor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ locked by the release manifest.
   service-manager probe itself is indeterminate
 - import operator-authorized networkless staging on retry only after checking
   its method and all recorded binary hashes
+- keep the repair manager outside systemd's pre-created
+  `unprivileged_userns` mount namespace so Codex can establish its required
+  Bubblewrap `workspace-write` sandbox under Ubuntu's AppArmor restrictions
 
 - wait for the actual FreeRDP relay window after Wine's short-lived Unix
   launcher exits, verify that the spawned GNOME daemon owns its configured

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -165,10 +165,19 @@ installers, extracted executables, Codex event logs, local journals, account
 state, and host-specific evidence remain ignored and outside Git.
 
 The Codex service uses `workspace-write`, `approval_policy="never"`,
-`NoNewPrivileges=yes`, private temporary files, a read-only system view, and a
-disabled Git push URL in the repair clone. Network access remains available
-because Codex authentication requires it. These controls reduce accidental
-reach; they are not a security boundary equivalent to a separate VM.
+`NoNewPrivileges=yes`, and a disabled Git push URL in the repair clone.
+Network access remains available because Codex authentication requires it.
+These controls reduce accidental reach; they are not a security boundary
+equivalent to a separate VM.
+
+The user service deliberately does not also request systemd mount-namespace
+features such as `PrivateTmp=`, `ProtectSystem=`, `ProtectKernelTunables=`, or
+`ProtectControlGroups=`. On Ubuntu 24.04 with restricted user namespaces,
+those user-manager options first place the updater inside AppArmor's
+`unprivileged_userns` profile. A nested Bubblewrap user namespace then fails,
+so Codex cannot provide `workspace-write`. The updater keeps the compatible
+service hardening and lets the Codex sandbox establish the filesystem
+boundary itself.
 
 On Ubuntu 24.04, `workspace-write` also needs Ubuntu's AppArmor profile for
 Bubblewrap. If status reports `codex-sandbox-deferred`, install and enable only
@@ -183,6 +192,20 @@ sudo install -o root -g root -m 0644 \
 sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 uu-remote update retry
 ```
+
+Confirm both layers before retrying:
+
+```bash
+systemd-run --user --wait --pipe --collect \
+  --property=NoNewPrivileges=yes \
+  /usr/bin/bwrap --die-with-parent --unshare-user --uid 0 --gid 0 \
+  --ro-bind / / /bin/true
+systemctl --user cat uu-remote-repair-monitor.service
+```
+
+The probe must exit successfully, and the service must not contain one of the
+systemd mount-namespace options listed above. Do not disable Ubuntu's global
+unprivileged-user-namespace restriction.
 
 `retry` keeps the private evidence and repair checkout, clears the unusable
 Codex thread, and starts a new thread on the next monitor run. It refuses

--- a/systemd/uu-remote-repair-monitor.service
+++ b/systemd/uu-remote-repair-monitor.service
@@ -10,10 +10,12 @@ UMask=0077
 Nice=10
 IOSchedulingClass=idle
 NoNewPrivileges=yes
-PrivateTmp=yes
-ProtectSystem=full
-ProtectKernelTunables=yes
-ProtectControlGroups=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+
+# Do not add user-manager options that require a systemd mount namespace
+# (PrivateTmp=, ProtectSystem=, ProtectKernelTunables=, or
+# ProtectControlGroups=). On Ubuntu's restricted-userns AppArmor setup that
+# puts this process in unprivileged_userns before Codex starts, which prevents
+# Bubblewrap from creating Codex's required workspace-write sandbox.

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -463,6 +463,9 @@ class UpdateManagerTests(unittest.TestCase):
     def test_systemd_timers_survive_boot_without_touching_the_bridge(self) -> None:
         daily = (REPO_DIR / "systemd/uu-remote-update-check.timer").read_text()
         monitor = (REPO_DIR / "systemd/uu-remote-repair-monitor.timer").read_text()
+        monitor_service = (
+            REPO_DIR / "systemd/uu-remote-repair-monitor.service"
+        ).read_text()
         check_service = (
             REPO_DIR / "systemd/uu-remote-update-check.service"
         ).read_text()
@@ -470,6 +473,14 @@ class UpdateManagerTests(unittest.TestCase):
         self.assertIn("OnBootSec=7min", monitor)
         self.assertIn("OnUnitInactiveSec=15min", monitor)
         self.assertNotIn("restart uu-remote-bridge", check_service)
+        self.assertIn("NoNewPrivileges=yes", monitor_service)
+        for incompatible_option in (
+            "PrivateTmp=yes",
+            "ProtectSystem=full",
+            "ProtectKernelTunables=yes",
+            "ProtectControlGroups=yes",
+        ):
+            self.assertNotIn(incompatible_option, monitor_service)
 
     def test_installer_exposes_opt_in_automatic_maintenance(self) -> None:
         installer = (REPO_DIR / "install.sh").read_text()


### PR DESCRIPTION
## Summary
- avoid user-level systemd mount namespaces that pre-confine the updater in AppArmor unprivileged_userns
- retain compatible service hardening while allowing Codex Bubblewrap workspace-write
- document the interaction and add a regression test

## Validation
- python3 -m unittest discover -s tests -v (62 passed)
- bash -n updater shell entrypoints
- systemd-analyze --user verify
- git diff --check