### PR TITLE
Keep automatic updater off the live relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ locked by the release manifest.
 - strip expiring CDN query keys from state, cap downloads, disable repair-clone
   pushes, and keep unknown UU binaries behind static staging and human semantic
   approval
-- defer every healthy-host deployment; restart and known-good reinstall occur
-  only after two consecutive health failures
+- make live recovery observation-only by default; restart and known-good
+  reinstall require an explicit `--auto-reinstall` opt-in after two
+  consecutive health failures
 
 ### Documentation
 

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -50,7 +50,7 @@ Two systemd user timers are enabled:
 | Timer | Schedule | Work |
 | --- | --- | --- |
 | `uu-remote-update-check.timer` | Daily around 04:20 with a randomized delay; also 12 minutes after boot | Fetch metadata and inspect the official UU endpoint without restarting the relay |
-| `uu-remote-repair-monitor.timer` | Seven minutes after boot and every 15 minutes after its previous run | Check relay health, resume a pending Codex thread, or perform bounded recovery when the relay is already unhealthy |
+| `uu-remote-repair-monitor.timer` | Seven minutes after boot and every 15 minutes after its previous run | Observe relay health and resume a pending Codex thread without changing the live relay |
 
 The daily timer uses `Persistent=true`, so a powered-off machine performs one
 missed check after its next boot. The repair timer does not need a logged-in
@@ -80,15 +80,17 @@ An endpoint that is equal to or older than the approved baseline is recorded
 and ignored. This matters because a release channel can temporarily advertise
 an older build. A different filename alone is not treated as an upgrade.
 
-The monitor changes the live relay only after health is bad twice, 20 seconds
-apart. An indeterminate user-manager query is recorded for repair and never
-treated as permission to restart. A confirmed failure permits one systemd
-restart. Known-good reinstallation is disabled by default; an operator must
-deliberately pass `--auto-reinstall` when configuring the updater. When opted
-in, it first clones the selected immutable track, runs the repository tests,
-and prebuilds compatibility artifacts while the already unhealthy relay
-remains untouched. Only the final reinstall reaches the live prefix. A healthy
-bridge is never periodically restarted for maintenance.
+The default monitor never changes the live relay. If health is bad twice,
+20 seconds apart, it records local evidence and queues analysis without
+stopping or restarting RDP, Wine, or UU. An indeterminate user-manager query
+is handled the same way.
+
+`--auto-reinstall` is a separate, explicit opt-in to live recovery. Only with
+that option may a confirmed failure permit one systemd restart followed by a
+known-good reinstall if restart fails. The recovery path first clones the
+selected immutable track, runs the repository tests, and prebuilds
+compatibility artifacts while the already unhealthy relay remains untouched.
+The default configuration used in this guide does not enable it.
 
 ## New upstream release workflow
 

--- a/docs/update-handoff.md
+++ b/docs/update-handoff.md
@@ -52,7 +52,9 @@ online, reconnect the phone and type: abcXYZ123,.!?
   `4.33.0.8907`.
 - Ask whether the installation is a direct clone or the parent repository's
   `code/uu-remote-ubuntu-bridge` submodule.
-- Warn that the updater restarts the bridge and briefly disconnects UU.
+- Explain that default updater checks and repair analysis never restart the
+  bridge. Warn about a brief UU/RDP interruption only if the recipient
+  explicitly opts in with `--auto-reinstall`.
 - Do not request passwords, Wine-prefix archives, or unredacted UU logs.
 
 ## Recipient preflight

--- a/scripts/configure-updater.sh
+++ b/scripts/configure-updater.sh
@@ -33,8 +33,9 @@ Enable options:
                          Codex reasoning effort (default: medium)
   --codex PATH           absolute Codex executable (default: current command)
   --idle-minutes N       documented maintenance idle window (default: 45)
-  --auto-reinstall       opt in to reinstalling the known-good track after a
-                         confirmed restart failure (default: disabled)
+  --auto-reinstall       opt in to live recovery: restart the bridge after two
+                         confirmed failures, then reinstall the known-good
+                         track if restart fails (default: disabled)
   --no-auto-reinstall    retain the safe default; accepted for compatibility
 EOF
 }

--- a/scripts/uu_update_manager.py
+++ b/scripts/uu_update_manager.py
@@ -1205,9 +1205,31 @@ class Manager:
             return
         if "bridge-service-query-failed" in confirmed["issues"]:
             details = self.runtime_context(first, confirmed)
+            details["confirmed_health"] = details.pop(
+                "health_after_restart", confirmed
+            )
             details["known_good_reinstall"] = {
                 "attempted": False,
                 "reason": "the service-manager probe was indeterminate",
+            }
+            identity = datetime.now().strftime("%Y%m%d-%H%M")
+            self.queue_task("runtime-health", identity, details)
+            return
+        if not self.config.auto_reinstall_known_good:
+            details = self.runtime_context(first, confirmed)
+            details["confirmed_health"] = details.pop(
+                "health_after_restart", confirmed
+            )
+            details["automatic_live_recovery"] = {
+                "attempted": False,
+                "reason": (
+                    "disabled by default so updater health observations cannot "
+                    "restart RDP or UU"
+                ),
+            }
+            details["known_good_reinstall"] = {
+                "attempted": False,
+                "reason": "automatic live recovery is disabled",
             }
             identity = datetime.now().strftime("%Y%m%d-%H%M")
             self.queue_task("runtime-health", identity, details)
@@ -1220,21 +1242,19 @@ class Manager:
                 message="the inactive relay recovered after one supervised restart",
             )
             return
-        reinstall: dict[str, Any] = {"attempted": False, "reason": "disabled"}
-        if self.config.auto_reinstall_known_good:
-            reinstall = self.reinstall_known_good()
-            if reinstall.get("health", {}).get("healthy"):
-                action = (
-                    "restored the previous runtime after a failed reinstall"
-                    if reinstall.get("rolled_back")
-                    else f"reinstalled known-good track {self.config.track}"
-                )
-                self.write_status(
-                    "self-healed",
-                    bridge_health=reinstall["health"],
-                    message=action,
-                )
-                return
+        reinstall = self.reinstall_known_good()
+        if reinstall.get("health", {}).get("healthy"):
+            action = (
+                "restored the previous runtime after a failed reinstall"
+                if reinstall.get("rolled_back")
+                else f"reinstalled known-good track {self.config.track}"
+            )
+            self.write_status(
+                "self-healed",
+                bridge_health=reinstall["health"],
+                message=action,
+            )
+            return
         details = self.runtime_context(first, restarted["health"])
         details["known_good_reinstall"] = reinstall
         identity = datetime.now().strftime("%Y%m%d-%H%M")

--- a/tests/test_update_manager.py
+++ b/tests/test_update_manager.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -622,6 +623,49 @@ class UpdateManagerTests(unittest.TestCase):
             self.assertEqual("runtime-health", manager.queued[0])
             self.assertFalse(
                 manager.queued[2]["known_good_reinstall"]["attempted"]
+            )
+
+    def test_default_health_monitor_never_restarts_the_live_bridge(self) -> None:
+        class ObservationOnlyManager(Manager):
+            def __init__(self, config):
+                super().__init__(config)
+                self.health_results = iter(
+                    (
+                        {"healthy": False, "issues": ["uu-server-missing"]},
+                        {"healthy": False, "issues": ["uu-server-missing"]},
+                    )
+                )
+                self.queued = None
+
+            def health(self):
+                return next(self.health_results)
+
+            def restart_bridge(self):
+                raise AssertionError("default monitoring must not restart RDP or UU")
+
+            def reinstall_known_good(self):
+                raise AssertionError("default monitoring must not reinstall UU")
+
+            def runtime_context(self, first, after):
+                return {"initial_health": first, "confirmed_health": after}
+
+            def queue_task(self, kind, identity, details):
+                self.queued = (kind, identity, details)
+                return {}
+
+        with tempfile.TemporaryDirectory() as temporary, patch(
+            "uu_update_manager.time.sleep", return_value=None
+        ):
+            config = replace(
+                self.config(Path(temporary)),
+                auto_reinstall_known_good=False,
+            )
+            manager = ObservationOnlyManager(config)
+            manager.monitor_health()
+            self.assertIsNotNone(manager.queued)
+            self.assertEqual("runtime-health", manager.queued[0])
+            self.assertFalse(
+                manager.queued[2]["automatic_live_recovery"]["attempted"]
             )
 
 


### PR DESCRIPTION
## Summary
- make default health monitoring observation-only
- prevent automatic RDP/UU bridge restarts when live recovery is disabled
- retain explicit --auto-reinstall as the only opt-in live recovery path
- document the boundary and add a regression test

## Validation
- python3 -m unittest discover -s tests -v (63 passed)
- bash -n updater scripts
- git diff --check