### PR TITLE
Fix UU cursor handling and X11 navigation keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ locked by the release manifest.
   promotes only a fully accepted UU build, preserves login and keyboard
   settings, refreshes bridge code, verifies XRDP state, and keeps local
   rollback copies
+- an opt-in process-local cursor guard for hosts where hidden or
+  cross-process-invalid Wine cursor handles break UU's independent cursor
+  channel; existing hosts retain the unmodified path by default
 
 ### Security
 
@@ -127,6 +130,8 @@ locked by the release manifest.
 - contain an upstream Wine memory or thread runaway with service-level memory,
   swap, and task ceilings so systemd rebuilds only the relay instead of
   allowing it to freeze the desktop
+- resolve extended direct-X11 navigation keys through the active display's
+  keysym map instead of assuming one fixed XFree86 keycode table
 
 - wait for the actual FreeRDP relay window after Wine's short-lived Unix
   launcher exits, verify that the spawned GNOME daemon owns its configured
@@ -141,7 +146,7 @@ locked by the release manifest.
 
 ### Validation
 
-- all 88 source, shell, documentation, updater, transaction, migration, and
+- all 90 source, shell, documentation, updater, transaction, migration, and
   helper-build tests pass
 - production promotion from UU `4.33.0.8907` to `4.34.0.8979` passed both
   runtime checks while preserving the account, direct-X11 input profile, and

--- a/README.md
+++ b/README.md
@@ -87,16 +87,15 @@ official UU window on the logged-in desktop before starting the private relay.
 Complete account sign-in and close that window. Re-running the same command is
 idempotent; unchanged FreeRDP build outputs are checksum-verified and reused.
 
-Port, resolution, private-display, cursor size, phone-text pacing, optional
-physical-key pacing, physical-key route, and an optional UU-only
-network-interface choice are persistent and can be set without editing the
-service:
+Port, resolution, private-display, phone-text pacing, optional physical-key
+pacing, physical-key route, and an optional UU-only network-interface choice
+are persistent and can be set without editing the service:
 
 ```bash
 ./install.sh --rdp-port 3391 --resolution 2560x1440 --display auto \
   --text-key-delay-ms 8 --physical-key-delay-ms 0 \
   --keyboard-route rdp \
-  --network-interface all --cursor-size auto
+  --network-interface all
 ```
 
 They are validated and stored in
@@ -107,11 +106,19 @@ Requested ports and fixed displays are checked before use. A conflicting
 non-GNOME listener fails closed, and an installer error restarts a bridge that
 was active before the attempted upgrade.
 
-`--cursor-size auto` reads the physical desktop's Xcursor size before Wine
-starts, so UU's process-local fallback cursor follows GNOME scaling without
-changing Wine DPI or the shared desktop geometry. Use a fixed value such as
-`--cursor-size 64` only when the controller still renders the independent
-cursor channel too small.
+The process-local cursor guard is a host-specific extension and defaults to
+`off`. Enable it only when the controller loses the cursor, renders it too
+small, or the UU server reports an invalid cross-process cursor handle:
+
+```bash
+./install.sh --skip-packages --skip-account-login \
+  --cursor-guard on --cursor-size auto
+```
+
+`auto` reads the physical desktop's Xcursor size before Wine starts. A fixed
+value such as `--cursor-size 64` changes only the guard's fallback arrow; it
+does not change Wine DPI or desktop geometry. Disable the extension with
+`--cursor-guard off` if the host does not need it.
 
 On the compatible `rdp` route, the default 8 ms text-key delay prevents UU's
 phone keyboard from overwhelming the Wine-to-FreeRDP input boundary. An
@@ -146,7 +153,9 @@ fails explicitly rather than becoming an unrelated key. The global default
 remains `rdp`; `auto` selects the direct route only for an X11 target. If
 preflight cannot verify the target display or helper before injection, the
 request safely uses the compatible RDP route. No event is replayed after an
-ambiguous partial injection.
+ambiguous partial injection. Extended navigation keys are resolved from
+keysyms on the active display rather than a fixed X11 keycode table, so the
+mapping follows the host layout.
 
 On the validated XRDP workstation, the first live direct-UU run produced 256
 content-free sampled physical-key calls on `route=x11`; every sampled call

--- a/README.md
+++ b/README.md
@@ -87,15 +87,16 @@ official UU window on the logged-in desktop before starting the private relay.
 Complete account sign-in and close that window. Re-running the same command is
 idempotent; unchanged FreeRDP build outputs are checksum-verified and reused.
 
-Port, resolution, private-display, phone-text pacing, optional physical-key
-pacing, physical-key route, and an optional UU-only network-interface choice
-are persistent and can be set without editing the service:
+Port, resolution, private-display, cursor size, phone-text pacing, optional
+physical-key pacing, physical-key route, and an optional UU-only
+network-interface choice are persistent and can be set without editing the
+service:
 
 ```bash
 ./install.sh --rdp-port 3391 --resolution 2560x1440 --display auto \
   --text-key-delay-ms 8 --physical-key-delay-ms 0 \
   --keyboard-route rdp \
-  --network-interface all
+  --network-interface all --cursor-size auto
 ```
 
 They are validated and stored in
@@ -105,6 +106,12 @@ sessions. A later plain `./install.sh` preserves these choices.
 Requested ports and fixed displays are checked before use. A conflicting
 non-GNOME listener fails closed, and an installer error restarts a bridge that
 was active before the attempted upgrade.
+
+`--cursor-size auto` reads the physical desktop's Xcursor size before Wine
+starts, so UU's process-local fallback cursor follows GNOME scaling without
+changing Wine DPI or the shared desktop geometry. Use a fixed value such as
+`--cursor-size 64` only when the controller still renders the independent
+cursor channel too small.
 
 On the compatible `rdp` route, the default 8 ms text-key delay prevents UU's
 phone keyboard from overwhelming the Wine-to-FreeRDP input boundary. An

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,24 @@ installer, for example:
   --grd-fd-restart-threshold 4096
 ```
 
+## UU cursor is visible but too small
+
+Keep the relay resolution and Wine DPI unchanged. The bridge defaults to
+`UURB_CURSOR_SIZE=auto`, which reads the physical GNOME Xcursor size and creates
+the same-sized process-local fallback cursor for UU's independent cursor
+channel. Restart the bridge after changing GNOME's pointer size.
+
+For a controller that still renders the cursor too small, set a fixed size:
+
+```bash
+sed -i 's/^UURB_CURSOR_SIZE=.*/UURB_CURSOR_SIZE=64/' \
+  ~/.config/uu-remote-bridge/environment
+systemctl --user restart uu-remote-bridge.service
+```
+
+Accepted values are `24` through `128`. This setting does not change XRDP, VNC,
+TeamViewer, the physical desktop resolution, or Wine's global DPI.
+
 ## Controller remains at “finding routes”
 
 This message can be misleading: the controller may be waiting for the host to

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,22 +22,29 @@ installer, for example:
   --grd-fd-restart-threshold 4096
 ```
 
-## UU cursor is visible but too small
+## UU cursor is missing or too small
 
-Keep the relay resolution and Wine DPI unchanged. The bridge defaults to
-`UURB_CURSOR_SIZE=auto`, which reads the physical GNOME Xcursor size and creates
-the same-sized process-local fallback cursor for UU's independent cursor
-channel. Restart the bridge after changing GNOME's pointer size.
-
-For a controller that still renders the cursor too small, set a fixed size:
+Keep the relay resolution and Wine DPI unchanged. The process-local cursor
+guard is an opt-in compatibility extension, so hosts with a working cursor do
+not load it. Enable it when the controller loses the cursor, renders it too
+small, or the UU server records `ERROR_INVALID_CURSOR_HANDLE`:
 
 ```bash
-sed -i 's/^UURB_CURSOR_SIZE=.*/UURB_CURSOR_SIZE=64/' \
-  ~/.config/uu-remote-bridge/environment
-systemctl --user restart uu-remote-bridge.service
+./install.sh --skip-packages --skip-account-login \
+  --cursor-guard on --cursor-size auto
 ```
 
-Accepted values are `24` through `128`. This setting does not change XRDP, VNC,
+`auto` reads the physical GNOME Xcursor size and creates the same-sized
+fallback arrow for UU's independent cursor channel. For a controller that
+still renders the cursor too small, use a fixed size:
+
+```bash
+./install.sh --skip-packages --skip-account-login \
+  --cursor-guard on --cursor-size 64
+```
+
+Accepted values are `24` through `128`. Disable the extension with
+`--cursor-guard off` when it is unnecessary. It does not change XRDP, VNC,
 TeamViewer, the physical desktop resolution, or Wine's global DPI.
 
 ## Controller remains at “finding routes”

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ saved_text_key_delay_ms="$(saved_setting UURB_TEXT_KEY_DELAY_MS)"
 saved_physical_key_delay_ms="$(saved_setting UURB_PHYSICAL_KEY_DELAY_MS)"
 saved_keyboard_route="$(saved_setting UURB_KEYBOARD_ROUTE)"
 saved_network_interface="$(saved_setting UURB_NETWORK_INTERFACE)"
+saved_cursor_size="$(saved_setting UURB_CURSOR_SIZE)"
 rdp_port="${UURB_RDP_PORT:-${saved_rdp_port:-3390}}"
 resolution="${UURB_RESOLUTION:-${saved_resolution:-1920x1080}}"
 bridge_display="${UURB_DISPLAY:-${saved_display:-auto}}"
@@ -63,6 +64,7 @@ text_key_delay_ms="$(resolve_text_key_delay \
 physical_key_delay_ms="${UURB_PHYSICAL_KEY_DELAY_MS:-${saved_physical_key_delay_ms:-0}}"
 keyboard_route="${UURB_KEYBOARD_ROUTE:-${saved_keyboard_route:-rdp}}"
 network_interface="${UURB_NETWORK_INTERFACE:-${saved_network_interface:-all}}"
+cursor_size="${UURB_CURSOR_SIZE:-${saved_cursor_size:-auto}}"
 uu_installer=''
 skip_packages=false
 skip_account_login=false
@@ -98,6 +100,8 @@ usage: ./install.sh [options]
   --network-interface all|default|IFACE
                          use all adapters (the default), Ubuntu's preferred
                          route, or one named interface
+  --cursor-size auto|N   match the physical desktop cursor automatically, or
+                         use a fixed size from 24 through 128 pixels
   --skip-packages        do not install Ubuntu/Wine package dependencies
   --skip-account-login   do not open UU for first-time account sign-in
   --unattended           enable TPM-backed startup after an automatic login
@@ -151,6 +155,10 @@ while (($#)); do
             ;;
         --network-interface)
             network_interface="${2:?--network-interface requires all, default, or an interface name}"
+            shift 2
+            ;;
+        --cursor-size)
+            cursor_size="${2:?--cursor-size requires auto or a pixel size}"
             shift 2
             ;;
         --skip-packages)
@@ -268,6 +276,12 @@ if [[ "$network_interface" != all &&
       ! -d "/sys/class/net/$network_interface" ]]; then
     printf 'The requested UU network interface does not exist: %s\n' \
         "$network_interface" >&2
+    exit 2
+fi
+if [[ "$cursor_size" != auto ]] &&
+   { [[ ! "$cursor_size" =~ ^[0-9]+$ ]] ||
+     ((cursor_size < 24 || cursor_size > 128)); }; then
+    printf 'The cursor size must be auto or an integer from 24 through 128.\n' >&2
     exit 2
 fi
 if [[ "$upgrade_existing" == true && -z "$uu_installer" ]]; then
@@ -532,6 +546,7 @@ fi
 mkdir -p "$wine_prefix/compat" "$freerdp_install" "$libei_install"
 install -m 0644 "$release_manifest" "$installed_manifest"
 install -m 0755 \
+    "$compat_build/uu-cursor-guard.dll" \
     "$compat_build/uu-input-bridge.dll" \
     "$compat_build/uu-input-broker.exe" \
     "$compat_build/uu-injector.exe" \
@@ -622,6 +637,8 @@ printf 'UURB_KEYBOARD_ROUTE=%s\n' \
     "$keyboard_route" >>"$environment_tmp"
 printf 'UURB_NETWORK_INTERFACE=%s\n' \
     "$network_interface" >>"$environment_tmp"
+printf 'UURB_CURSOR_SIZE=%s\n' \
+    "$cursor_size" >>"$environment_tmp"
 chmod 0600 "$environment_tmp"
 mv "$environment_tmp" "$environment_file"
 install -m 0755 "$repo_dir/scripts/uu-remote-bridge" \

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ saved_text_key_delay_ms="$(saved_setting UURB_TEXT_KEY_DELAY_MS)"
 saved_physical_key_delay_ms="$(saved_setting UURB_PHYSICAL_KEY_DELAY_MS)"
 saved_keyboard_route="$(saved_setting UURB_KEYBOARD_ROUTE)"
 saved_network_interface="$(saved_setting UURB_NETWORK_INTERFACE)"
+saved_cursor_guard="$(saved_setting UURB_CURSOR_GUARD)"
 saved_cursor_size="$(saved_setting UURB_CURSOR_SIZE)"
 rdp_port="${UURB_RDP_PORT:-${saved_rdp_port:-3390}}"
 resolution="${UURB_RESOLUTION:-${saved_resolution:-1920x1080}}"
@@ -64,6 +65,7 @@ text_key_delay_ms="$(resolve_text_key_delay \
 physical_key_delay_ms="${UURB_PHYSICAL_KEY_DELAY_MS:-${saved_physical_key_delay_ms:-0}}"
 keyboard_route="${UURB_KEYBOARD_ROUTE:-${saved_keyboard_route:-rdp}}"
 network_interface="${UURB_NETWORK_INTERFACE:-${saved_network_interface:-all}}"
+cursor_guard="${UURB_CURSOR_GUARD:-${saved_cursor_guard:-off}}"
 cursor_size="${UURB_CURSOR_SIZE:-${saved_cursor_size:-auto}}"
 uu_installer=''
 skip_packages=false
@@ -100,7 +102,9 @@ usage: ./install.sh [options]
   --network-interface all|default|IFACE
                          use all adapters (the default), Ubuntu's preferred
                          route, or one named interface
-  --cursor-size auto|N   match the physical desktop cursor automatically, or
+  --cursor-guard off|on  opt into the process-local UU cursor workaround
+                         (default: off)
+  --cursor-size auto|N   with the cursor guard on, match the desktop cursor or
                          use a fixed size from 24 through 128 pixels
   --skip-packages        do not install Ubuntu/Wine package dependencies
   --skip-account-login   do not open UU for first-time account sign-in
@@ -155,6 +159,10 @@ while (($#)); do
             ;;
         --network-interface)
             network_interface="${2:?--network-interface requires all, default, or an interface name}"
+            shift 2
+            ;;
+        --cursor-guard)
+            cursor_guard="${2:?--cursor-guard requires off or on}"
             shift 2
             ;;
         --cursor-size)
@@ -278,11 +286,20 @@ if [[ "$network_interface" != all &&
         "$network_interface" >&2
     exit 2
 fi
-if [[ "$cursor_size" != auto ]] &&
-   { [[ ! "$cursor_size" =~ ^[0-9]+$ ]] ||
-     ((cursor_size < 24 || cursor_size > 128)); }; then
-    printf 'The cursor size must be auto or an integer from 24 through 128.\n' >&2
+if [[ "$cursor_guard" != off && "$cursor_guard" != on ]]; then
+    printf 'The cursor guard must be off or on.\n' >&2
     exit 2
+fi
+if [[ "$cursor_size" != auto ]]; then
+    if [[ ! "$cursor_size" =~ ^[0-9]{1,3}$ ]]; then
+        printf 'The cursor size must be auto or an integer from 24 through 128.\n' >&2
+        exit 2
+    fi
+    cursor_size=$((10#$cursor_size))
+    if ((cursor_size < 24 || cursor_size > 128)); then
+        printf 'The cursor size must be auto or an integer from 24 through 128.\n' >&2
+        exit 2
+    fi
 fi
 if [[ "$upgrade_existing" == true && -z "$uu_installer" ]]; then
     printf -- '--upgrade-existing requires --uu-installer with an audited file.\n' >&2
@@ -637,6 +654,8 @@ printf 'UURB_KEYBOARD_ROUTE=%s\n' \
     "$keyboard_route" >>"$environment_tmp"
 printf 'UURB_NETWORK_INTERFACE=%s\n' \
     "$network_interface" >>"$environment_tmp"
+printf 'UURB_CURSOR_GUARD=%s\n' \
+    "$cursor_guard" >>"$environment_tmp"
 printf 'UURB_CURSOR_SIZE=%s\n' \
     "$cursor_size" >>"$environment_tmp"
 chmod 0600 "$environment_tmp"

--- a/scripts/build-compat.sh
+++ b/scripts/build-compat.sh
@@ -25,6 +25,9 @@ mkdir -p "$output_dir"
 "$cc" "${common[@]}" "${pe_link[@]}" -shared \
     -o "$output_dir/uu-input-bridge.dll" \
     "$repo_dir/src/uu_input_bridge.c" -luser32
+"$cc" "${common[@]}" "${pe_link[@]}" -shared \
+    -o "$output_dir/uu-cursor-guard.dll" \
+    "$repo_dir/src/uu_cursor_guard.c" -luser32 -lgdi32
 "$cc" "${common[@]}" "${pe_link[@]}" -municode -mwindows \
     -o "$output_dir/uu-input-broker.exe" \
     "$repo_dir/src/uu_input_broker.c" -luser32 -lws2_32
@@ -48,6 +51,7 @@ mkdir -p "$output_dir"
     "$repo_dir/src/uu_x11_input.c" -ldl
 
 "$strip" \
+    "$output_dir/uu-cursor-guard.dll" \
     "$output_dir/uu-input-bridge.dll" \
     "$output_dir/uu-input-broker.exe" \
     "$output_dir/uu-injector.exe" \

--- a/scripts/runtime-source-digest
+++ b/scripts/runtime-source-digest
@@ -26,6 +26,7 @@ runtime_files=(
     scripts/uu-remote-bridge
     scripts/upgrade-uu-remote.sh
     scripts/verify.sh
+    src/uu_cursor_guard.c
     src/uu_injector.c
     src/uu_input_bridge.c
     src/uu_input_broker.c

--- a/scripts/uu-remote-bridge
+++ b/scripts/uu-remote-bridge
@@ -11,6 +11,7 @@ text_key_delay_ms="${UURB_TEXT_KEY_DELAY_MS:-8}"
 physical_key_delay_ms="${UURB_PHYSICAL_KEY_DELAY_MS:-0}"
 keyboard_route="${UURB_KEYBOARD_ROUTE:-rdp}"
 network_interface="${UURB_NETWORK_INTERFACE:-all}"
+cursor_size_setting="${UURB_CURSOR_SIZE:-auto}"
 wine_prefix="${UURB_WINEPREFIX:-$HOME/.local/share/wineprefixes/uu-remote}"
 manager_display="${DISPLAY:-}"
 manager_wayland="${WAYLAND_DISPLAY:-}"
@@ -36,8 +37,10 @@ if [[ "$bridge_display" != auto &&
    [[ "$network_interface" != all &&
       "$network_interface" != default &&
       ! "$network_interface" =~ ^[a-zA-Z0-9_.:-]{1,15}$ ]] ||
+   [[ "$cursor_size_setting" != auto &&
+      ! "$cursor_size_setting" =~ ^[0-9]+$ ]] ||
    [[ "$wine_prefix" != /* ]]; then
-    printf 'Invalid UURB display, RDP port, resolution, descriptor, keyboard, network, or prefix setting.\n' >&2
+    printf 'Invalid UURB display, RDP port, resolution, descriptor, keyboard, network, cursor, or prefix setting.\n' >&2
     exit 2
 fi
 resolution_width="${resolution%x*}"
@@ -49,7 +52,12 @@ if ((rdp_port < 1024 || rdp_port > 65535 ||
       (grd_fd_restart_threshold < 512 ||
        grd_fd_restart_threshold > 60000)) ||
      text_key_delay_ms > 50 || physical_key_delay_ms > 50)); then
-    printf 'UURB port, resolution, descriptor threshold, or keyboard delay is outside the supported range.\n' >&2
+    printf 'UURB port, resolution, descriptor threshold, keyboard delay, or cursor size is outside the supported range.\n' >&2
+    exit 2
+fi
+if [[ "$cursor_size_setting" != auto ]] &&
+   ((cursor_size_setting < 24 || cursor_size_setting > 128)); then
+    printf 'UURB cursor size is outside the supported range.\n' >&2
     exit 2
 fi
 
@@ -83,6 +91,7 @@ export OPENSSL_MODULES='C:\Program Files\FreeRDP\ossl-modules'
 export SDL_RENDER_DRIVER=software
 export UU_INPUT_BRIDGE_LOG="C:\\users\\$bridge_user\\Temp\\uu-input-bridge.log"
 export UU_INPUT_BROKER_LOG="C:\\users\\$bridge_user\\Temp\\uu-input-broker.log"
+export UURB_CURSOR_GUARD_LOG="C:\\users\\$bridge_user\\Temp\\uu-cursor-guard.log"
 export UURB_TEXT_KEY_DELAY_MS="$text_key_delay_ms"
 export UURB_PHYSICAL_KEY_DELAY_MS="$physical_key_delay_ms"
 export PATH="/opt/wine-stable/bin:/usr/bin:/bin"
@@ -92,6 +101,9 @@ runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$UID}/uu-remote-bridge"
 compat_dir="$WINEPREFIX/compat"
 libei_dir="$compat_dir/libei"
 freerdp_exe="$WINEPREFIX/drive_c/Program Files/FreeRDP/sdl-freerdp.exe"
+cursor_guard_dll="$compat_dir/uu-cursor-guard.dll"
+cursor_guard_log="$WINEPREFIX/drive_c/users/$bridge_user/Temp/uu-cursor-guard.log"
+cursor_reader_guard_log="$WINEPREFIX/drive_c/users/$bridge_user/AppData/Local/Temp/uu-cursor-guard.log"
 input_bridge_dll="$compat_dir/uu-input-bridge.dll"
 input_broker_exe="$compat_dir/uu-input-broker.exe"
 x11_input_helper="$compat_dir/uu-x11-input"
@@ -125,6 +137,7 @@ desktop_session_type=""
 desktop_xauthority=""
 active_network_interface=""
 active_keyboard_route="rdp"
+cursor_size=""
 x11_input_port=""
 x11_input_token=""
 
@@ -165,6 +178,45 @@ default_network_interface() {
                     print route_metric, interface
             }
         ' | /usr/bin/sort -n -k1,1 | /usr/bin/awk 'NR == 1 {print $2}'
+}
+
+resolve_cursor_size() {
+    local -a display_environment
+    local detected=""
+
+    if [[ "$cursor_size_setting" != auto ]]; then
+        cursor_size="$cursor_size_setting"
+    elif [[ -n "$desktop_display" ]]; then
+        display_environment=(
+            /usr/bin/env
+            "DISPLAY=$desktop_display"
+        )
+        if [[ -n "$desktop_xauthority" ]]; then
+            display_environment+=("XAUTHORITY=$desktop_xauthority")
+        fi
+        detected="$(
+            "${display_environment[@]}" /usr/bin/xrdb -query 2>/dev/null | \
+                /usr/bin/awk '
+                    $1 == "Xcursor.size:" && $2 ~ /^[0-9]+$/ {
+                        print $2
+                        exit
+                    }
+                '
+        )"
+    fi
+
+    if [[ "$cursor_size_setting" == auto ]]; then
+        if [[ "$detected" =~ ^[0-9]+$ ]] &&
+           ((detected >= 24 && detected <= 128)); then
+            cursor_size="$detected"
+        else
+            # GNOME's gsettings value is logical and may omit compositor scale.
+            cursor_size=48
+        fi
+    fi
+
+    export UURB_CURSOR_SIZE="$cursor_size"
+    log "UU cursor compatibility size is ${cursor_size}x${cursor_size}."
 }
 
 cleanup() {
@@ -485,6 +537,7 @@ fi
 if ! start_desktop_relay; then
     exit 1
 fi
+resolve_cursor_size
 start_x11_input_helper
 
 touch "$xauth_file"
@@ -523,7 +576,8 @@ if [[ ! -f "$freerdp_exe" ]]; then
     exit 1
 fi
 
-if [[ ! -f "$input_bridge_dll" || ! -f "$input_broker_exe" ||
+if [[ ! -f "$cursor_guard_dll" ||
+      ! -f "$input_bridge_dll" || ! -f "$input_broker_exe" ||
       ! -f "$input_injector_exe" || ! -f "$service_control_exe" ]]; then
     log 'The UU input compatibility bridge is missing from the Wine prefix.'
     exit 1
@@ -613,10 +667,37 @@ fi
 input_bridge_windows_path="$(
     /opt/wine-stable/bin/winepath -w "$input_bridge_dll"
 )"
+cursor_guard_windows_path="$(
+    /opt/wine-stable/bin/winepath -w "$cursor_guard_dll"
+)"
 if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
     "$input_bridge_windows_path" \
     >>"$state_dir/input-injector.log" 2>&1; then
     log 'Could not inject the UU input compatibility bridge.'
+    exit 1
+fi
+rm -f "$cursor_reader_guard_log"
+if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
+    "$cursor_guard_windows_path" GameViewerServer.exe \
+    >>"$state_dir/cursor-reader-guard-injector.log" 2>&1; then
+    log 'Could not inject the UU cursor reader guard.'
+    exit 1
+fi
+cursor_reader_guard_ready=false
+for _ in {1..100}; do
+    if grep -q 'UU cursor reader guard active' \
+        "$cursor_reader_guard_log" 2>/dev/null; then
+        cursor_reader_guard_ready=true
+        break
+    fi
+    if grep -q 'UU cursor reader guard initialization failed' \
+        "$cursor_reader_guard_log" 2>/dev/null; then
+        break
+    fi
+    sleep 0.05
+done
+if [[ "$cursor_reader_guard_ready" != true ]]; then
+    log 'The UU cursor reader guard did not initialize.'
     exit 1
 fi
 server_pid="$(pgrep -o -u "$UID" -f 'GameViewerServer\.exe')"
@@ -633,6 +714,7 @@ server_pid="$(pgrep -o -u "$UID" -f 'GameViewerServer\.exe')"
     /bpp:32 \
     /gdi:sw \
     /audio-mode:2 \
+    /mouse:relative:off,grab:off \
     /prevent-session-lock:180 \
     /t:Ubuntu-Desktop-Relay \
     +f \
@@ -661,6 +743,31 @@ done
 
 if [[ "$relay_ready" != true ]]; then
     log 'FreeRDP did not create the Ubuntu desktop relay window.'
+    exit 1
+fi
+
+rm -f "$cursor_guard_log"
+if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
+    "$cursor_guard_windows_path" sdl-freerdp.exe \
+    >>"$state_dir/cursor-guard-injector.log" 2>&1; then
+    log 'Could not inject the FreeRDP cursor guard.'
+    exit 1
+fi
+cursor_guard_ready=false
+for _ in {1..100}; do
+    if grep -q 'UU relay cursor guard active' \
+        "$cursor_guard_log" 2>/dev/null; then
+        cursor_guard_ready=true
+        break
+    fi
+    if grep -q 'UU cursor guard initialization failed' \
+        "$cursor_guard_log" 2>/dev/null; then
+        break
+    fi
+    sleep 0.05
+done
+if [[ "$cursor_guard_ready" != true ]]; then
+    log 'The FreeRDP cursor guard did not initialize.'
     exit 1
 fi
 

--- a/scripts/uu-remote-bridge
+++ b/scripts/uu-remote-bridge
@@ -11,6 +11,7 @@ text_key_delay_ms="${UURB_TEXT_KEY_DELAY_MS:-8}"
 physical_key_delay_ms="${UURB_PHYSICAL_KEY_DELAY_MS:-0}"
 keyboard_route="${UURB_KEYBOARD_ROUTE:-rdp}"
 network_interface="${UURB_NETWORK_INTERFACE:-all}"
+cursor_guard_setting="${UURB_CURSOR_GUARD:-off}"
 cursor_size_setting="${UURB_CURSOR_SIZE:-auto}"
 wine_prefix="${UURB_WINEPREFIX:-$HOME/.local/share/wineprefixes/uu-remote}"
 manager_display="${DISPLAY:-}"
@@ -37,8 +38,10 @@ if [[ "$bridge_display" != auto &&
    [[ "$network_interface" != all &&
       "$network_interface" != default &&
       ! "$network_interface" =~ ^[a-zA-Z0-9_.:-]{1,15}$ ]] ||
+   [[ "$cursor_guard_setting" != off &&
+      "$cursor_guard_setting" != on ]] ||
    [[ "$cursor_size_setting" != auto &&
-      ! "$cursor_size_setting" =~ ^[0-9]+$ ]] ||
+      ! "$cursor_size_setting" =~ ^[0-9]{1,3}$ ]] ||
    [[ "$wine_prefix" != /* ]]; then
     printf 'Invalid UURB display, RDP port, resolution, descriptor, keyboard, network, cursor, or prefix setting.\n' >&2
     exit 2
@@ -52,13 +55,15 @@ if ((rdp_port < 1024 || rdp_port > 65535 ||
       (grd_fd_restart_threshold < 512 ||
        grd_fd_restart_threshold > 60000)) ||
      text_key_delay_ms > 50 || physical_key_delay_ms > 50)); then
-    printf 'UURB port, resolution, descriptor threshold, keyboard delay, or cursor size is outside the supported range.\n' >&2
+    printf 'UURB port, resolution, descriptor threshold, or keyboard delay is outside the supported range.\n' >&2
     exit 2
 fi
-if [[ "$cursor_size_setting" != auto ]] &&
-   ((cursor_size_setting < 24 || cursor_size_setting > 128)); then
-    printf 'UURB cursor size is outside the supported range.\n' >&2
-    exit 2
+if [[ "$cursor_size_setting" != auto ]]; then
+    cursor_size_setting=$((10#$cursor_size_setting))
+    if ((cursor_size_setting < 24 || cursor_size_setting > 128)); then
+        printf 'UURB cursor size is outside the supported range.\n' >&2
+        exit 2
+    fi
 fi
 
 if [[ "$bridge_display" == auto ]]; then
@@ -198,7 +203,8 @@ resolve_cursor_size() {
             "${display_environment[@]}" /usr/bin/xrdb -query 2>/dev/null | \
                 /usr/bin/awk '
                     $1 == "Xcursor.size:" && $2 ~ /^[0-9]+$/ {
-                        print $2
+                        if (length($2) <= 3)
+                            print $2
                         exit
                     }
                 '
@@ -206,6 +212,9 @@ resolve_cursor_size() {
     fi
 
     if [[ "$cursor_size_setting" == auto ]]; then
+        if [[ "$detected" =~ ^[0-9]{1,3}$ ]]; then
+            detected=$((10#$detected))
+        fi
         if [[ "$detected" =~ ^[0-9]+$ ]] &&
            ((detected >= 24 && detected <= 128)); then
             cursor_size="$detected"
@@ -537,7 +546,9 @@ fi
 if ! start_desktop_relay; then
     exit 1
 fi
-resolve_cursor_size
+if [[ "$cursor_guard_setting" == on ]]; then
+    resolve_cursor_size
+fi
 start_x11_input_helper
 
 touch "$xauth_file"
@@ -576,10 +587,13 @@ if [[ ! -f "$freerdp_exe" ]]; then
     exit 1
 fi
 
-if [[ ! -f "$cursor_guard_dll" ||
-      ! -f "$input_bridge_dll" || ! -f "$input_broker_exe" ||
+if [[ ! -f "$input_bridge_dll" || ! -f "$input_broker_exe" ||
       ! -f "$input_injector_exe" || ! -f "$service_control_exe" ]]; then
     log 'The UU input compatibility bridge is missing from the Wine prefix.'
+    exit 1
+fi
+if [[ "$cursor_guard_setting" == on && ! -f "$cursor_guard_dll" ]]; then
+    log 'The optional UU cursor guard is missing from the Wine prefix.'
     exit 1
 fi
 
@@ -667,41 +681,47 @@ fi
 input_bridge_windows_path="$(
     /opt/wine-stable/bin/winepath -w "$input_bridge_dll"
 )"
-cursor_guard_windows_path="$(
-    /opt/wine-stable/bin/winepath -w "$cursor_guard_dll"
-)"
 if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
     "$input_bridge_windows_path" \
     >>"$state_dir/input-injector.log" 2>&1; then
     log 'Could not inject the UU input compatibility bridge.'
     exit 1
 fi
-rm -f "$cursor_reader_guard_log"
-if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
-    "$cursor_guard_windows_path" GameViewerServer.exe \
-    >>"$state_dir/cursor-reader-guard-injector.log" 2>&1; then
-    log 'Could not inject the UU cursor reader guard.'
-    exit 1
-fi
-cursor_reader_guard_ready=false
-for _ in {1..100}; do
-    if grep -q 'UU cursor reader guard active' \
-        "$cursor_reader_guard_log" 2>/dev/null; then
-        cursor_reader_guard_ready=true
-        break
+if [[ "$cursor_guard_setting" == on ]]; then
+    cursor_guard_windows_path="$(
+        /opt/wine-stable/bin/winepath -w "$cursor_guard_dll"
+    )"
+    rm -f "$cursor_reader_guard_log"
+    if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
+        "$cursor_guard_windows_path" GameViewerServer.exe \
+        >>"$state_dir/cursor-reader-guard-injector.log" 2>&1; then
+        log 'Could not inject the UU cursor reader guard.'
+        exit 1
     fi
-    if grep -q 'UU cursor reader guard initialization failed' \
-        "$cursor_reader_guard_log" 2>/dev/null; then
-        break
+    cursor_reader_guard_ready=false
+    for _ in {1..100}; do
+        if grep -q 'UU cursor reader guard active' \
+            "$cursor_reader_guard_log" 2>/dev/null; then
+            cursor_reader_guard_ready=true
+            break
+        fi
+        if grep -q 'UU cursor reader guard initialization failed' \
+            "$cursor_reader_guard_log" 2>/dev/null; then
+            break
+        fi
+        sleep 0.05
+    done
+    if [[ "$cursor_reader_guard_ready" != true ]]; then
+        log 'The UU cursor reader guard did not initialize.'
+        exit 1
     fi
-    sleep 0.05
-done
-if [[ "$cursor_reader_guard_ready" != true ]]; then
-    log 'The UU cursor reader guard did not initialize.'
-    exit 1
 fi
 server_pid="$(pgrep -o -u "$UID" -f 'GameViewerServer\.exe')"
 
+freerdp_mouse_options=()
+if [[ "$cursor_guard_setting" == on ]]; then
+    freerdp_mouse_options+=(/mouse:relative:off,grab:off)
+fi
 /opt/wine-stable/bin/wine "$freerdp_exe" \
     "/v:127.0.0.1:$rdp_port" \
     "/u:$bridge_user" \
@@ -714,7 +734,7 @@ server_pid="$(pgrep -o -u "$UID" -f 'GameViewerServer\.exe')"
     /bpp:32 \
     /gdi:sw \
     /audio-mode:2 \
-    /mouse:relative:off,grab:off \
+    "${freerdp_mouse_options[@]}" \
     /prevent-session-lock:180 \
     /t:Ubuntu-Desktop-Relay \
     +f \
@@ -746,29 +766,31 @@ if [[ "$relay_ready" != true ]]; then
     exit 1
 fi
 
-rm -f "$cursor_guard_log"
-if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
-    "$cursor_guard_windows_path" sdl-freerdp.exe \
-    >>"$state_dir/cursor-guard-injector.log" 2>&1; then
-    log 'Could not inject the FreeRDP cursor guard.'
-    exit 1
-fi
-cursor_guard_ready=false
-for _ in {1..100}; do
-    if grep -q 'UU relay cursor guard active' \
-        "$cursor_guard_log" 2>/dev/null; then
-        cursor_guard_ready=true
-        break
+if [[ "$cursor_guard_setting" == on ]]; then
+    rm -f "$cursor_guard_log"
+    if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
+        "$cursor_guard_windows_path" sdl-freerdp.exe \
+        >>"$state_dir/cursor-guard-injector.log" 2>&1; then
+        log 'Could not inject the FreeRDP cursor guard.'
+        exit 1
     fi
-    if grep -q 'UU cursor guard initialization failed' \
-        "$cursor_guard_log" 2>/dev/null; then
-        break
+    cursor_guard_ready=false
+    for _ in {1..100}; do
+        if grep -q 'UU relay cursor guard active' \
+            "$cursor_guard_log" 2>/dev/null; then
+            cursor_guard_ready=true
+            break
+        fi
+        if grep -q 'UU cursor guard initialization failed' \
+            "$cursor_guard_log" 2>/dev/null; then
+            break
+        fi
+        sleep 0.05
+    done
+    if [[ "$cursor_guard_ready" != true ]]; then
+        log 'The FreeRDP cursor guard did not initialize.'
+        exit 1
     fi
-    sleep 0.05
-done
-if [[ "$cursor_guard_ready" != true ]]; then
-    log 'The FreeRDP cursor guard did not initialize.'
-    exit 1
 fi
 
 relay_window_id="$(

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -63,6 +63,8 @@ saved_rdp_port="$(saved_setting UURB_RDP_PORT)"
 rdp_port="${UURB_RDP_PORT:-${saved_rdp_port:-3390}}"
 saved_keyboard_route="$(saved_setting UURB_KEYBOARD_ROUTE)"
 keyboard_route="${UURB_KEYBOARD_ROUTE:-${saved_keyboard_route:-rdp}}"
+saved_cursor_guard="$(saved_setting UURB_CURSOR_GUARD)"
+cursor_guard_setting="${UURB_CURSOR_GUARD:-${saved_cursor_guard:-off}}"
 
 relay_listener_ready() {
     /usr/bin/ss -H -ltnp "sport = :$rdp_port" 2>/dev/null | \
@@ -222,16 +224,31 @@ relay_pid="$(pgrep -n -u "$UID" -x 'sdl-freerdp.exe' || true)"
 cursor_server_pid="$(
     pgrep -o -u "$UID" -f 'GameViewerServer\.exe' || true
 )"
-if [[ -f "$cursor_guard" && -n "$relay_pid" &&
-      -n "$cursor_server_pid" ]] &&
-   grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null &&
-   grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" 2>/dev/null &&
-   grep -q 'UU relay cursor guard active' "$cursor_guard_log" 2>/dev/null &&
-   grep -q 'UU cursor reader guard active' \
-       "$cursor_reader_guard_log" 2>/dev/null; then
-    pass 'relay and UU cursor guards are active'
+if [[ "$cursor_guard_setting" == on ]]; then
+    if [[ -f "$cursor_guard" && -n "$relay_pid" &&
+          -n "$cursor_server_pid" ]] &&
+       grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null &&
+       grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" 2>/dev/null &&
+       grep -q 'UU relay cursor guard active' \
+           "$cursor_guard_log" 2>/dev/null &&
+       grep -q 'UU cursor reader guard active' \
+           "$cursor_reader_guard_log" 2>/dev/null; then
+        pass 'opt-in relay and UU cursor guards are active'
+    else
+        fail 'opt-in relay or UU cursor guard is missing or inactive'
+    fi
+elif [[ "$cursor_guard_setting" == off ]]; then
+    if { [[ -z "$relay_pid" ]] ||
+         ! grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null; } &&
+       { [[ -z "$cursor_server_pid" ]] ||
+         ! grep -Fq "$cursor_guard" \
+             "/proc/$cursor_server_pid/maps" 2>/dev/null; }; then
+        pass 'optional cursor guard is disabled and not loaded'
+    else
+        fail 'cursor guard state does not match the disabled setting'
+    fi
 else
-    fail 'relay or UU cursor guard is missing or inactive'
+    fail 'cursor guard setting is neither off nor on'
 fi
 
 if [[ -f "$bridge_log" ]] && \

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,6 +37,9 @@ case "$release_version" in
         ;;
 esac
 freerdp="$wine_prefix/drive_c/Program Files/FreeRDP/sdl-freerdp.exe"
+cursor_guard="$wine_prefix/compat/uu-cursor-guard.dll"
+cursor_guard_log="$wine_prefix/drive_c/users/$bridge_user/Temp/uu-cursor-guard.log"
+cursor_reader_guard_log="$wine_prefix/drive_c/users/$bridge_user/AppData/Local/Temp/uu-cursor-guard.log"
 libei_backport="$wine_prefix/compat/libei/libei.so.1.2.1"
 network_filter="$wine_prefix/compat/uu-network-filter.so"
 x11_input_helper="$wine_prefix/compat/uu-x11-input"
@@ -213,6 +216,22 @@ if [[ -f "$freerdp" ]] && \
     pass 'pinned Windows FreeRDP SDL client is installed'
 else
     fail 'Windows FreeRDP SDL client verification failed'
+fi
+
+relay_pid="$(pgrep -n -u "$UID" -x 'sdl-freerdp.exe' || true)"
+cursor_server_pid="$(
+    pgrep -o -u "$UID" -f 'GameViewerServer\.exe' || true
+)"
+if [[ -f "$cursor_guard" && -n "$relay_pid" &&
+      -n "$cursor_server_pid" ]] &&
+   grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null &&
+   grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" 2>/dev/null &&
+   grep -q 'UU relay cursor guard active' "$cursor_guard_log" 2>/dev/null &&
+   grep -q 'UU cursor reader guard active' \
+       "$cursor_reader_guard_log" 2>/dev/null; then
+    pass 'relay and UU cursor guards are active'
+else
+    fail 'relay or UU cursor guard is missing or inactive'
 fi
 
 if [[ -f "$bridge_log" ]] && \

--- a/src/uu_cursor_guard.c
+++ b/src/uu_cursor_guard.c
@@ -1,0 +1,398 @@
+#define UNICODE
+#define _UNICODE
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+
+#define DEFAULT_CURSOR_SIZE 48U
+#define MIN_CURSOR_SIZE 24U
+#define MAX_CURSOR_SIZE 128U
+
+typedef HCURSOR(WINAPI *set_cursor_fn)(HCURSOR);
+typedef BOOL(WINAPI *get_cursor_info_fn)(PCURSORINFO);
+typedef BOOL(WINAPI *get_icon_info_fn)(HICON, PICONINFO);
+
+static set_cursor_fn original_set_cursor;
+static get_cursor_info_fn original_get_cursor_info;
+static get_icon_info_fn original_get_icon_info;
+static HCURSOR fallback_cursor;
+static UINT fallback_cursor_width;
+static UINT fallback_cursor_height;
+static HANDLE log_file = INVALID_HANDLE_VALUE;
+static volatile LONG hidden_cursor_count;
+
+static void write_log(const char *message)
+{
+    DWORD written;
+
+    if (log_file == INVALID_HANDLE_VALUE)
+        return;
+    WriteFile(log_file, message, (DWORD)strlen(message), &written, NULL);
+}
+
+static void open_log(void)
+{
+    wchar_t path[MAX_PATH];
+    DWORD length;
+
+    length = GetEnvironmentVariableW(L"UURB_CURSOR_GUARD_LOG", path, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH) {
+        length = GetTempPathW(MAX_PATH, path);
+        if (length == 0 || length >= MAX_PATH - 20)
+            lstrcpynW(path, L"uu-cursor-guard.log", MAX_PATH);
+        else
+            lstrcatW(path, L"uu-cursor-guard.log");
+    }
+
+    log_file = CreateFileW(path, FILE_APPEND_DATA,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                           OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+}
+
+static UINT configured_cursor_size(void)
+{
+    wchar_t value[16];
+    wchar_t *end;
+    unsigned long parsed;
+    DWORD length;
+
+    length = GetEnvironmentVariableW(
+        L"UURB_CURSOR_SIZE", value, sizeof(value) / sizeof(value[0]));
+    if (length == 0 || length >= sizeof(value) / sizeof(value[0]))
+        return DEFAULT_CURSOR_SIZE;
+
+    parsed = wcstoul(value, &end, 10);
+    if (end == value || *end != L'\0' ||
+        parsed < MIN_CURSOR_SIZE || parsed > MAX_CURSOR_SIZE)
+        return DEFAULT_CURSOR_SIZE;
+    return (UINT)parsed;
+}
+
+static BOOL cursor_dimensions(HCURSOR cursor, UINT *width, UINT *height)
+{
+    ICONINFO icon;
+    BITMAP bitmap;
+    HBITMAP source;
+    LONG bitmap_width;
+    LONG bitmap_height;
+    BOOL result = FALSE;
+
+    ZeroMemory(&icon, sizeof(icon));
+    ZeroMemory(&bitmap, sizeof(bitmap));
+    if (!GetIconInfo(cursor, &icon))
+        return FALSE;
+
+    source = icon.hbmColor != NULL ? icon.hbmColor : icon.hbmMask;
+    if (source != NULL &&
+        GetObjectW(source, (int)sizeof(bitmap), &bitmap) != 0) {
+        bitmap_width =
+            bitmap.bmWidth < 0 ? -bitmap.bmWidth : bitmap.bmWidth;
+        bitmap_height =
+            bitmap.bmHeight < 0 ? -bitmap.bmHeight : bitmap.bmHeight;
+        if (icon.hbmColor == NULL)
+            bitmap_height /= 2;
+        if (bitmap_width > 0 && bitmap_height > 0) {
+            *width = (UINT)bitmap_width;
+            *height = (UINT)bitmap_height;
+            result = TRUE;
+        }
+    }
+
+    if (icon.hbmMask != NULL)
+        DeleteObject(icon.hbmMask);
+    if (icon.hbmColor != NULL)
+        DeleteObject(icon.hbmColor);
+    return result;
+}
+
+static BOOL load_fallback_cursor(void)
+{
+    HCURSOR base_cursor;
+    UINT requested_size;
+
+    requested_size = configured_cursor_size();
+    base_cursor = LoadCursorW(NULL, IDC_ARROW);
+    if (base_cursor == NULL)
+        return FALSE;
+
+    fallback_cursor = (HCURSOR)CopyImage(
+        base_cursor, IMAGE_CURSOR, (int)requested_size,
+        (int)requested_size, LR_DEFAULTCOLOR);
+    if (fallback_cursor == NULL ||
+        !cursor_dimensions(fallback_cursor, &fallback_cursor_width,
+                           &fallback_cursor_height) ||
+        fallback_cursor_width != requested_size ||
+        fallback_cursor_height != requested_size) {
+        if (fallback_cursor != NULL)
+            DestroyCursor(fallback_cursor);
+        fallback_cursor = base_cursor;
+        if (!cursor_dimensions(fallback_cursor, &fallback_cursor_width,
+                               &fallback_cursor_height))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static void write_active_log(const char *guard_name)
+{
+    char message[128];
+    int length;
+
+    length = snprintf(message, sizeof(message),
+                      "%s active (cursor %ux%u)\r\n", guard_name,
+                      fallback_cursor_width, fallback_cursor_height);
+    if (length > 0 && (size_t)length < sizeof(message))
+        write_log(message);
+}
+
+static HCURSOR WINAPI guarded_set_cursor(HCURSOR cursor)
+{
+    if (cursor == NULL) {
+        cursor = fallback_cursor;
+        if (InterlockedIncrement(&hidden_cursor_count) == 1)
+            write_log("UU cursor guard replaced a hidden cursor\r\n");
+    }
+
+    if (original_set_cursor == NULL)
+        return NULL;
+    return original_set_cursor(cursor);
+}
+
+static BOOL WINAPI guarded_get_cursor_info(PCURSORINFO cursor)
+{
+    BOOL result;
+
+    if (original_get_cursor_info == NULL)
+        return FALSE;
+    result = original_get_cursor_info(cursor);
+    if (result && cursor != NULL) {
+        cursor->flags = CURSOR_SHOWING;
+        cursor->hCursor = fallback_cursor;
+    }
+    return result;
+}
+
+static BOOL WINAPI guarded_get_icon_info(HICON icon, PICONINFO info)
+{
+    BOOL result;
+    DWORD error;
+
+    if (original_get_icon_info == NULL)
+        return FALSE;
+    result = original_get_icon_info(icon, info);
+    if (result)
+        return TRUE;
+
+    error = GetLastError();
+    if (error != ERROR_INVALID_CURSOR_HANDLE || fallback_cursor == NULL)
+        return FALSE;
+    return original_get_icon_info(fallback_cursor, info);
+}
+
+static BOOL cursor_reader_self_test(void)
+{
+    CURSORINFO cursor;
+    ICONINFO icon;
+
+    ZeroMemory(&cursor, sizeof(cursor));
+    cursor.cbSize = sizeof(cursor);
+    if (!guarded_get_cursor_info(&cursor) ||
+        cursor.hCursor != fallback_cursor ||
+        fallback_cursor_width == 0 || fallback_cursor_height == 0 ||
+        (cursor.flags & CURSOR_SHOWING) == 0)
+        return FALSE;
+
+    ZeroMemory(&icon, sizeof(icon));
+    if (!guarded_get_icon_info(cursor.hCursor, &icon))
+        return FALSE;
+    if (icon.hbmMask != NULL)
+        DeleteObject(icon.hbmMask);
+    if (icon.hbmColor != NULL)
+        DeleteObject(icon.hbmColor);
+    return TRUE;
+}
+
+static BOOL patch_import(HMODULE module, const char *dll_name,
+                         const char *function_name, uintptr_t replacement,
+                         uintptr_t *original)
+{
+    BYTE *base = (BYTE *)module;
+    IMAGE_DOS_HEADER *dos = (IMAGE_DOS_HEADER *)base;
+    IMAGE_NT_HEADERS *nt;
+    IMAGE_IMPORT_DESCRIPTOR *descriptor;
+
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE)
+        return FALSE;
+
+    nt = (IMAGE_NT_HEADERS *)(base + dos->e_lfanew);
+    if (nt->Signature != IMAGE_NT_SIGNATURE)
+        return FALSE;
+
+    descriptor = (IMAGE_IMPORT_DESCRIPTOR *)(
+        base + nt->OptionalHeader
+                   .DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT]
+                   .VirtualAddress);
+    if ((BYTE *)descriptor == base)
+        return FALSE;
+
+    for (; descriptor->Name != 0; descriptor++) {
+        const char *imported_dll = (const char *)(base + descriptor->Name);
+        IMAGE_THUNK_DATA *names;
+        IMAGE_THUNK_DATA *addresses;
+
+        if (_stricmp(imported_dll, dll_name) != 0)
+            continue;
+
+        names = descriptor->OriginalFirstThunk != 0
+                    ? (IMAGE_THUNK_DATA *)(base + descriptor->OriginalFirstThunk)
+                    : (IMAGE_THUNK_DATA *)(base + descriptor->FirstThunk);
+        addresses = (IMAGE_THUNK_DATA *)(base + descriptor->FirstThunk);
+
+        for (; names->u1.AddressOfData != 0; names++, addresses++) {
+            IMAGE_IMPORT_BY_NAME *import_name;
+            DWORD old_protection;
+
+            if (IMAGE_SNAP_BY_ORDINAL(names->u1.Ordinal))
+                continue;
+            import_name = (IMAGE_IMPORT_BY_NAME *)(
+                base + names->u1.AddressOfData);
+            if (strcmp((const char *)import_name->Name, function_name) != 0)
+                continue;
+
+            if (original != NULL)
+                *original = (uintptr_t)addresses->u1.Function;
+            if (!VirtualProtect(&addresses->u1.Function,
+                                sizeof(addresses->u1.Function),
+                                PAGE_READWRITE, &old_protection))
+                return FALSE;
+            addresses->u1.Function = (ULONGLONG)replacement;
+            FlushInstructionCache(GetCurrentProcess(),
+                                  &addresses->u1.Function,
+                                  sizeof(addresses->u1.Function));
+            VirtualProtect(&addresses->u1.Function,
+                           sizeof(addresses->u1.Function), old_protection,
+                           &old_protection);
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+static DWORD WINAPI initialize_guard(void *unused)
+{
+    HMODULE main_module;
+    HMODULE streamer_module;
+    HWND relay;
+    wchar_t executable[MAX_PATH];
+    const wchar_t *process_name;
+    wchar_t *separator;
+    uintptr_t set_cursor_address = 0;
+    uintptr_t get_cursor_info_address = 0;
+    uintptr_t get_icon_info_address = 0;
+    BOOL cursor_info_patched;
+    BOOL icon_info_patched;
+    BOOL streamer_cursor_info_patched;
+    BOOL streamer_icon_info_patched;
+
+    (void)unused;
+    open_log();
+    if (GetModuleFileNameW(NULL, executable, MAX_PATH) == 0 ||
+        !load_fallback_cursor()) {
+        write_log("UU cursor guard initialization failed\r\n");
+        if (log_file != INVALID_HANDLE_VALUE)
+            FlushFileBuffers(log_file);
+        return 1;
+    }
+
+    separator = wcsrchr(executable, L'\\');
+    process_name = separator == NULL ? executable : separator + 1;
+    main_module = GetModuleHandleW(NULL);
+    if (_wcsicmp(process_name, L"sdl-freerdp.exe") == 0) {
+        if (!patch_import(main_module, "USER32.dll", "SetCursor",
+                          (uintptr_t)&guarded_set_cursor,
+                          &set_cursor_address)) {
+            write_log("UU cursor guard initialization failed\r\n");
+            if (log_file != INVALID_HANDLE_VALUE)
+                FlushFileBuffers(log_file);
+            return 1;
+        }
+        original_set_cursor = (set_cursor_fn)set_cursor_address;
+        if (original_set_cursor == NULL) {
+            write_log("UU cursor guard initialization failed\r\n");
+            if (log_file != INVALID_HANDLE_VALUE)
+                FlushFileBuffers(log_file);
+            return 1;
+        }
+
+        original_set_cursor(fallback_cursor);
+        relay = FindWindowW(NULL, L"Ubuntu-Desktop-Relay");
+        if (relay != NULL)
+            PostMessageW(relay, WM_SETCURSOR, (WPARAM)relay,
+                         MAKELPARAM(HTCLIENT, WM_MOUSEMOVE));
+        write_active_log("UU relay cursor guard");
+    } else if (_wcsicmp(process_name, L"GameViewerServer.exe") == 0) {
+        cursor_info_patched = patch_import(
+            main_module, "USER32.dll", "GetCursorInfo",
+            (uintptr_t)&guarded_get_cursor_info,
+            &get_cursor_info_address);
+        icon_info_patched = patch_import(
+            main_module, "USER32.dll", "GetIconInfo",
+            (uintptr_t)&guarded_get_icon_info,
+            &get_icon_info_address);
+        original_get_cursor_info =
+            (get_cursor_info_fn)get_cursor_info_address;
+        original_get_icon_info = (get_icon_info_fn)get_icon_info_address;
+        streamer_module = GetModuleHandleW(L"streamer.dll");
+        streamer_cursor_info_patched =
+            streamer_module != NULL &&
+            patch_import(streamer_module, "USER32.dll", "GetCursorInfo",
+                         (uintptr_t)&guarded_get_cursor_info, NULL);
+        streamer_icon_info_patched =
+            streamer_module != NULL &&
+            patch_import(streamer_module, "USER32.dll", "GetIconInfo",
+                         (uintptr_t)&guarded_get_icon_info, NULL);
+        if (!cursor_info_patched || !icon_info_patched ||
+            !streamer_cursor_info_patched || !streamer_icon_info_patched ||
+            original_get_cursor_info == NULL ||
+            original_get_icon_info == NULL ||
+            !cursor_reader_self_test()) {
+            write_log("UU cursor reader guard initialization failed\r\n");
+            if (log_file != INVALID_HANDLE_VALUE)
+                FlushFileBuffers(log_file);
+            return 1;
+        }
+        write_active_log("UU cursor reader guard");
+    } else {
+        write_log("UU cursor guard initialization failed\r\n");
+        if (log_file != INVALID_HANDLE_VALUE)
+            FlushFileBuffers(log_file);
+        return 1;
+    }
+
+    if (log_file != INVALID_HANDLE_VALUE)
+        FlushFileBuffers(log_file);
+    return 0;
+}
+
+BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
+{
+    HANDLE thread;
+
+    (void)reserved;
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(instance);
+        thread = CreateThread(NULL, 0, initialize_guard, NULL, 0, NULL);
+        if (thread != NULL)
+            CloseHandle(thread);
+    } else if (reason == DLL_PROCESS_DETACH &&
+               log_file != INVALID_HANDLE_VALUE) {
+        CloseHandle(log_file);
+        log_file = INVALID_HANDLE_VALUE;
+    }
+    return TRUE;
+}

--- a/src/uu_cursor_guard.c
+++ b/src/uu_cursor_guard.c
@@ -34,19 +34,32 @@ static void write_log(const char *message)
     WriteFile(log_file, message, (DWORD)strlen(message), &written, NULL);
 }
 
-static void open_log(void)
+static void default_log_path(wchar_t *path)
 {
-    wchar_t path[MAX_PATH];
     DWORD length;
 
-    length = GetEnvironmentVariableW(L"UURB_CURSOR_GUARD_LOG", path, MAX_PATH);
-    if (length == 0 || length >= MAX_PATH) {
-        length = GetTempPathW(MAX_PATH, path);
-        if (length == 0 || length >= MAX_PATH - 20)
-            lstrcpynW(path, L"uu-cursor-guard.log", MAX_PATH);
-        else
-            lstrcatW(path, L"uu-cursor-guard.log");
-    }
+    length = GetTempPathW(MAX_PATH, path);
+    if (length == 0 || length >= MAX_PATH - 20)
+        lstrcpynW(path, L"uu-cursor-guard.log", MAX_PATH);
+    else
+        lstrcatW(path, L"uu-cursor-guard.log");
+}
+
+static void open_log(const wchar_t *process_name)
+{
+    wchar_t path[MAX_PATH];
+    DWORD length = 0;
+
+    /*
+     * Wine services do not reliably inherit the bridge environment. Keep the
+     * server guard on its process-local temp path even when launch order
+     * changes; the relay guard uses the explicit bridge log path.
+     */
+    if (_wcsicmp(process_name, L"GameViewerServer.exe") != 0)
+        length = GetEnvironmentVariableW(
+            L"UURB_CURSOR_GUARD_LOG", path, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH)
+        default_log_path(path);
 
     log_file = CreateFileW(path, FILE_APPEND_DATA,
                            FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
@@ -300,17 +313,18 @@ static DWORD WINAPI initialize_guard(void *unused)
     BOOL streamer_icon_info_patched;
 
     (void)unused;
-    open_log();
-    if (GetModuleFileNameW(NULL, executable, MAX_PATH) == 0 ||
-        !load_fallback_cursor()) {
+    if (GetModuleFileNameW(NULL, executable, MAX_PATH) == 0)
+        return 1;
+    separator = wcsrchr(executable, L'\\');
+    process_name = separator == NULL ? executable : separator + 1;
+    open_log(process_name);
+    if (!load_fallback_cursor()) {
         write_log("UU cursor guard initialization failed\r\n");
         if (log_file != INVALID_HANDLE_VALUE)
             FlushFileBuffers(log_file);
         return 1;
     }
 
-    separator = wcsrchr(executable, L'\\');
-    process_name = separator == NULL ? executable : separator + 1;
     main_module = GetModuleHandleW(NULL);
     if (_wcsicmp(process_name, L"sdl-freerdp.exe") == 0) {
         if (!patch_import(main_module, "USER32.dll", "SetCursor",

--- a/src/uu_x11_input.c
+++ b/src/uu_x11_input.c
@@ -19,9 +19,12 @@
 /* Keep the helper buildable with runtime X11 libraries only. */
 typedef struct _XDisplay Display;
 typedef int Bool;
+typedef unsigned long KeySym;
+typedef unsigned char KeyCode;
 typedef Display *(*x_open_display_fn)(const char *);
 typedef int (*x_close_display_fn)(Display *);
 typedef int (*x_sync_fn)(Display *, Bool);
+typedef KeyCode (*x_keysym_to_keycode_fn)(Display *, KeySym);
 typedef Bool (*xtest_query_extension_fn)(Display *, int *, int *, int *, int *);
 typedef Bool (*xtest_fake_key_event_fn)(Display *, unsigned int, Bool,
                                         unsigned long);
@@ -32,6 +35,7 @@ typedef struct x11_api {
     x_open_display_fn open_display;
     x_close_display_fn close_display;
     x_sync_fn sync;
+    x_keysym_to_keycode_fn keysym_to_keycode;
     xtest_query_extension_fn query_extension;
     xtest_fake_key_event_fn fake_key_event;
 } x11_api;
@@ -116,58 +120,64 @@ static void sleep_milliseconds(uint64_t milliseconds)
         ;
 }
 
-static unsigned int extended_scan_to_x_keycode(unsigned int scan)
+static KeySym extended_scan_to_keysym(unsigned int scan)
 {
     switch (scan) {
     case 0x1c:
-        return 108; /* keypad Enter */
+        return 0xff8dUL; /* XK_KP_Enter */
     case 0x1d:
-        return 109; /* right Control */
+        return 0xffe4UL; /* XK_Control_R */
     case 0x35:
-        return 112; /* keypad Divide */
+        return 0xffafUL; /* XK_KP_Divide */
     case 0x37:
-        return 111; /* Print */
+        return 0xff61UL; /* XK_Print */
     case 0x38:
-        return 113; /* right Alt */
+        return 0xffeaUL; /* XK_Alt_R */
     case 0x47:
-        return 97;  /* Home */
+        return 0xff50UL; /* XK_Home */
     case 0x48:
-        return 98;  /* Up */
+        return 0xff52UL; /* XK_Up */
     case 0x49:
-        return 99;  /* Page Up */
+        return 0xff55UL; /* XK_Prior */
     case 0x4b:
-        return 100; /* Left */
+        return 0xff51UL; /* XK_Left */
     case 0x4d:
-        return 102; /* Right */
+        return 0xff53UL; /* XK_Right */
     case 0x4f:
-        return 103; /* End */
+        return 0xff57UL; /* XK_End */
     case 0x50:
-        return 104; /* Down */
+        return 0xff54UL; /* XK_Down */
     case 0x51:
-        return 105; /* Page Down */
+        return 0xff56UL; /* XK_Next */
     case 0x52:
-        return 106; /* Insert */
+        return 0xff63UL; /* XK_Insert */
     case 0x53:
-        return 107; /* Delete */
+        return 0xffffUL; /* XK_Delete */
     case 0x5b:
-        return 115; /* left Super */
+        return 0xffebUL; /* XK_Super_L */
     case 0x5c:
-        return 116; /* right Super */
+        return 0xffecUL; /* XK_Super_R */
     case 0x5d:
-        return 117; /* Menu */
+        return 0xff67UL; /* XK_Menu */
     default:
         return 0;
     }
 }
 
-static unsigned int event_to_x_keycode(const uurb_x11_key_event *event)
+static unsigned int event_to_x_keycode(const x11_api *api, Display *display,
+                                       const uurb_x11_key_event *event)
 {
     unsigned int scan = event->scan_code & 0xffU;
 
     if (scan == 0 || (event->flags & UURB_KEYEVENTF_UNICODE) != 0)
         return 0;
-    if ((event->flags & UURB_KEYEVENTF_EXTENDED) != 0)
-        return extended_scan_to_x_keycode(scan);
+    if ((event->flags & UURB_KEYEVENTF_EXTENDED) != 0) {
+        KeySym keysym = extended_scan_to_keysym(scan);
+
+        if (keysym == 0)
+            return 0;
+        return api->keysym_to_keycode(display, keysym);
+    }
     if (scan > 247U)
         return 0;
     return scan + 8U;
@@ -192,11 +202,14 @@ static bool load_x11_api(x11_api *api)
     api->close_display = (x_close_display_fn)dlsym(api->x11_library,
                                                    "XCloseDisplay");
     api->sync = (x_sync_fn)dlsym(api->x11_library, "XSync");
+    api->keysym_to_keycode = (x_keysym_to_keycode_fn)dlsym(
+        api->x11_library, "XKeysymToKeycode");
     api->query_extension = (xtest_query_extension_fn)dlsym(
         api->xtst_library, "XTestQueryExtension");
     api->fake_key_event = (xtest_fake_key_event_fn)dlsym(
         api->xtst_library, "XTestFakeKeyEvent");
     if (!api->open_display || !api->close_display || !api->sync ||
+        !api->keysym_to_keycode ||
         !api->query_extension || !api->fake_key_event)
         return false;
 
@@ -340,7 +353,8 @@ static void serve_client(int client, const char *token, x11_api *api,
             break;
 
         for (index = 0; index < request.count; index++) {
-            keycodes[index] = event_to_x_keycode(&events[index]);
+            keycodes[index] = event_to_x_keycode(api, display,
+                                                 &events[index]);
             if (keycodes[index] == 0) {
                 error = UURB_X11_ERROR_UNSUPPORTED;
                 break;

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -164,6 +164,7 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn("UURB_PHYSICAL_KEY_DELAY_MS=%s", installer)
         self.assertIn("UURB_KEYBOARD_ROUTE=%s", installer)
         self.assertIn("UURB_NETWORK_INTERFACE=%s", installer)
+        self.assertIn("UURB_CURSOR_SIZE=%s", installer)
         self.assertIn("resolve_text_key_delay", installer)
         self.assertIn("EnvironmentFile=-%h/.config/uu-remote-bridge/environment", unit)
         self.assertIn('bridge_display="${UURB_DISPLAY:-auto}"', launcher)
@@ -185,6 +186,16 @@ class RuntimeScriptTests(unittest.TestCase):
         )
         self.assertIn(
             'network_interface="${UURB_NETWORK_INTERFACE:-all}"',
+            launcher,
+        )
+        self.assertIn(
+            'cursor_size_setting="${UURB_CURSOR_SIZE:-auto}"',
+            launcher,
+        )
+        self.assertIn("resolve_cursor_size", launcher)
+        self.assertIn('export UURB_CURSOR_SIZE="$cursor_size"', launcher)
+        self.assertNotIn(
+            "org.gnome.desktop.interface cursor-size",
             launcher,
         )
         self.assertIn(
@@ -365,6 +376,47 @@ class RuntimeScriptTests(unittest.TestCase):
 
         self.assertIn("+clipboard", launcher)
         self.assertNotIn("-clipboard", launcher)
+
+    def test_nested_relay_uses_absolute_ungrabbed_mouse(self):
+        launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
+
+        self.assertIn("/mouse:relative:off,grab:off", launcher)
+        self.assertNotIn("+mouse-relative", launcher)
+
+    def test_hidden_cursor_guard_is_scoped_to_the_relay(self):
+        guard = (REPOSITORY / "src" / "uu_cursor_guard.c").read_text()
+        builder = (REPOSITORY / "scripts" / "build-compat.sh").read_text()
+        installer = (REPOSITORY / "install.sh").read_text()
+        launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
+        verifier = (REPOSITORY / "scripts" / "verify.sh").read_text()
+        digest = (REPOSITORY / "scripts" / "runtime-source-digest").read_text()
+
+        self.assertIn('"SetCursor"', guard)
+        self.assertIn('"GetCursorInfo"', guard)
+        self.assertIn('"GetIconInfo"', guard)
+        self.assertIn("if (cursor == NULL)", guard)
+        self.assertIn("IDC_ARROW", guard)
+        self.assertIn("CopyImage(", guard)
+        self.assertIn('L"UURB_CURSOR_SIZE"', guard)
+        self.assertIn("cursor_dimensions", guard)
+        self.assertIn("fallback_cursor_width != requested_size", guard)
+        self.assertIn("cursor->flags = CURSOR_SHOWING", guard)
+        self.assertNotIn("cursor->flags |= CURSOR_SHOWING", guard)
+        self.assertNotIn('"ClipCursor"', guard)
+        self.assertNotIn('"ShowCursor"', guard)
+        for source in (builder, installer, launcher, verifier):
+            self.assertIn("uu-cursor-guard.dll", source)
+        self.assertIn("src/uu_cursor_guard.c", digest)
+        injection = launcher.index(
+            '"$cursor_guard_windows_path" sdl-freerdp.exe'
+        )
+        reader_injection = launcher.index(
+            '"$cursor_guard_windows_path" GameViewerServer.exe'
+        )
+        bootstrap = launcher.index("\nbootstrap_account\n", injection)
+        self.assertLess(reader_injection, injection)
+        self.assertLess(injection, bootstrap)
+        self.assertIn("pgrep -n -u \"$UID\" -x 'sdl-freerdp.exe'", verifier)
 
     def test_phone_ime_unicode_input_is_normalized(self):
         bridge = (REPOSITORY / "src" / "uu_input_bridge.c").read_text()

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -164,6 +164,7 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn("UURB_PHYSICAL_KEY_DELAY_MS=%s", installer)
         self.assertIn("UURB_KEYBOARD_ROUTE=%s", installer)
         self.assertIn("UURB_NETWORK_INTERFACE=%s", installer)
+        self.assertIn("UURB_CURSOR_GUARD=%s", installer)
         self.assertIn("UURB_CURSOR_SIZE=%s", installer)
         self.assertIn("resolve_text_key_delay", installer)
         self.assertIn("EnvironmentFile=-%h/.config/uu-remote-bridge/environment", unit)
@@ -192,6 +193,11 @@ class RuntimeScriptTests(unittest.TestCase):
             'cursor_size_setting="${UURB_CURSOR_SIZE:-auto}"',
             launcher,
         )
+        self.assertIn(
+            'cursor_guard_setting="${UURB_CURSOR_GUARD:-off}"',
+            launcher,
+        )
+        self.assertIn("--cursor-guard off|on", installer)
         self.assertIn("resolve_cursor_size", launcher)
         self.assertIn('export UURB_CURSOR_SIZE="$cursor_size"', launcher)
         self.assertNotIn(
@@ -377,13 +383,26 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn("+clipboard", launcher)
         self.assertNotIn("-clipboard", launcher)
 
-    def test_nested_relay_uses_absolute_ungrabbed_mouse(self):
+    def test_opt_in_cursor_guard_uses_absolute_ungrabbed_mouse(self):
         launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
 
-        self.assertIn("/mouse:relative:off,grab:off", launcher)
+        options = launcher.index("freerdp_mouse_options=()")
+        guard = launcher.index(
+            'if [[ "$cursor_guard_setting" == on ]]; then',
+            options,
+        )
+        mouse = launcher.index(
+            "freerdp_mouse_options+=(/mouse:relative:off,grab:off)",
+            guard,
+        )
+        relay = launcher.index('"${freerdp_mouse_options[@]}"', mouse)
+        self.assertLess(options, guard)
+        self.assertLess(guard, mouse)
+        self.assertLess(mouse, relay)
+        self.assertEqual(launcher.count("/mouse:relative:off,grab:off"), 1)
         self.assertNotIn("+mouse-relative", launcher)
 
-    def test_hidden_cursor_guard_is_scoped_to_the_relay(self):
+    def test_hidden_cursor_guard_is_opt_in_and_process_scoped(self):
         guard = (REPOSITORY / "src" / "uu_cursor_guard.c").read_text()
         builder = (REPOSITORY / "scripts" / "build-compat.sh").read_text()
         installer = (REPOSITORY / "install.sh").read_text()
@@ -404,9 +423,27 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertNotIn("cursor->flags |= CURSOR_SHOWING", guard)
         self.assertNotIn('"ClipCursor"', guard)
         self.assertNotIn('"ShowCursor"', guard)
+        self.assertIn("open_log(process_name)", guard)
+        self.assertIn(
+            '_wcsicmp(process_name, L"GameViewerServer.exe") != 0',
+            guard,
+        )
         for source in (builder, installer, launcher, verifier):
             self.assertIn("uu-cursor-guard.dll", source)
         self.assertIn("src/uu_cursor_guard.c", digest)
+        self.assertIn(
+            'cursor_guard_setting="${UURB_CURSOR_GUARD:-off}"',
+            launcher,
+        )
+        self.assertIn('[[ "$cursor_guard_setting" == on ]]', launcher)
+        self.assertIn(
+            "optional cursor guard is disabled and not loaded",
+            verifier,
+        )
+        self.assertIn(
+            "opt-in relay and UU cursor guards are active",
+            verifier,
+        )
         injection = launcher.index(
             '"$cursor_guard_windows_path" sdl-freerdp.exe'
         )

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -480,6 +480,13 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn("ERROR_CONNECTION_ABORTED", broker)
         self.assertIn("release_pressed_keys", helper)
         self.assertIn("minimum_hold_ms", helper)
+        self.assertIn("XKeysymToKeycode", helper)
+        self.assertIn("extended_scan_to_keysym", helper)
+        self.assertIn("0xff52UL; /* XK_Up */", helper)
+        self.assertIn("0xff54UL; /* XK_Down */", helper)
+        self.assertIn("0xff51UL; /* XK_Left */", helper)
+        self.assertIn("0xff53UL; /* XK_Right */", helper)
+        self.assertNotIn("return 104; /* Down */", helper)
         self.assertNotIn("XTestFakeButtonEvent", helper)
 
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- keep the nested SDL FreeRDP relay on absolute, ungrabbed mouse input
- add a process-local cursor guard for hidden and cross-process-invalid Wine cursor handles
- add persistent `UURB_CURSOR_SIZE=auto|24..128` sizing without changing Wine DPI or desktop geometry
- resolve Windows extended scan codes through `XKeysymToKeycode` instead of fixed X11 keycodes

## Root causes

GNOME RDP can send a hidden cursor, and the cursor handle created in the Wine FreeRDP process is not reliably readable by `GameViewerServer.exe` (`ERROR_INVALID_CURSOR_HANDLE`). The guard supplies a valid process-local cursor only at those compatibility boundaries.

The direct-X11 keyboard helper also assumed a fixed XFree86 keycode table. On a physical Ubuntu Xorg desktop, those numbers map to IME keys and keypad Enter: for example, the old Down mapping injected keycode 104 (`KP_Enter`). Looking up navigation keysyms on the active display produces the correct layout-specific keycodes.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` (90 tests)
- `scripts/build-compat.sh`
- clean detached worktree build and `git diff --check`
- live Xorg `:0` injection observed `Up=111`, `Down=116`, `Left=113`, and `Right=114`
- live bridge restart confirmed both cursor guards active and configurable 56x56 controller cursor

The fallback intentionally favors a visible standard arrow when the source cursor is hidden or cannot be read across Wine processes.