### PR TITLE
fix: refresh FreeRDP runtime and stabilize verification

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Compile Python
         run: python3 -m compileall -q scripts tests
 
+      - name: Install test compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64-win32
+
       - name: Run unit and documentation tests
         run: python3 -m unittest discover -s tests -v
 

--- a/docs/reverse-engineering.md
+++ b/docs/reverse-engineering.md
@@ -209,7 +209,8 @@ The Windows SDL FreeRDP client rendered reliably in the same Wine/X display,
 but Wine's SSPI handle representation did not satisfy its NLA path. The
 solution was:
 
-1. Build `libwinpr3.dll` from pinned FreeRDP 3.30.0 source with MinGW.
+1. Build `libwinpr3.dll` from the source revision matching the pinned FreeRDP
+   Windows client with MinGW.
 2. Enable WinPR's internal MD4, MD5, and RC4 implementations. Wine could not
    reliably load OpenSSL's legacy provider, and NTLM requires MD4.
 3. Disable native SSPI so the shim always reaches WinPR's implementation.
@@ -218,8 +219,9 @@ solution was:
    `none,ntlm` with `/auth-pkg-list`.
 
 The shim calls WinPR's `InitSecurityInterfaceExA/W` and normalizes the private
-credential/context handle-name field around `AcquireCredentialsHandle` and
-`InitializeSecurityContext`.
+credential/context package-identity field around `AcquireCredentialsHandle`
+and `InitializeSecurityContext`. WinPR 3.31 stores an inverted numeric package
+ID in that field; older releases used an inverted package-name pointer.
 
 ## Tools used
 

--- a/scripts/build-winpr.sh
+++ b/scripts/build-winpr.sh
@@ -12,9 +12,11 @@ build_dir="$work_dir/build"
 build_recipe="$output_dir/.build-recipe"
 build_checksums="$output_dir/.build-sha256"
 
-freerdp_commit='6b107f0aadbabc47941c5a5b893b88c01792af6d'
-sdl_url='https://ci.freerdp.com/job/freerdp-nightly-windows/arch=win64,label=vs2017/2038/artifact/install/bin/sdl-freerdp.exe'
-sdl_sha256='1534187d731b2e4a6cb6d1107c0129727517fe3acf1441b5a2567aea5ea31d60'
+# Jenkins prunes old nightly artifacts. Keep the Windows client and the
+# separately-built WinPR runtime on the exact same retained source revision.
+freerdp_commit='168925dac792142f6d0b66e7e2d568a3d439521c'
+sdl_url='https://ci.freerdp.com/job/freerdp-nightly-windows/arch=win64,label=vs2017/2064/artifact/install/bin/sdl-freerdp.exe'
+sdl_sha256='b384347b6d0dd1e0c9912d18f5993b4e30643470e2a627e112debb34e8710762'
 openssl_url='https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-openssl-3.6.3-1-any.pkg.tar.zst'
 openssl_sha256='82de7ff886112374ffae9e7b3c843c82342e198543fb024790416ef56434fe9f'
 cjson_url='https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-cjson-1.7.19-1-any.pkg.tar.zst'

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -394,7 +394,7 @@ fi
 
 if [[ -f "$freerdp" ]] && \
    [[ "$(sha256sum "$freerdp" | awk '{print $1}')" == \
-      1534187d731b2e4a6cb6d1107c0129727517fe3acf1441b5a2567aea5ea31d60 ]]; then
+      b384347b6d0dd1e0c9912d18f5993b4e30643470e2a627e112debb34e8710762 ]]; then
     pass 'pinned Windows FreeRDP SDL client is installed'
 else
     fail 'Windows FreeRDP SDL client verification failed'

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -404,21 +404,39 @@ relay_pid="$(pgrep -n -u "$UID" -x 'sdl-freerdp.exe' || true)"
 cursor_server_pid="$(
     pgrep -o -u "$UID" -f 'GameViewerServer\.exe' || true
 )"
+
+cursor_reader_guard_ready() {
+    [[ -f "$cursor_guard" && -n "$cursor_server_pid" ]] &&
+        grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" \
+            2>/dev/null &&
+        grep -q 'UU cursor reader guard active' \
+            "$cursor_reader_guard_log" 2>/dev/null
+}
+
+cursor_relay_guard_ready() {
+    [[ -f "$cursor_guard" && -n "$relay_pid" ]] &&
+        grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null &&
+        grep -q 'UU relay cursor guard active' \
+            "$cursor_guard_log" 2>/dev/null
+}
+
 if [[ "$cursor_guard_setting" == on ]]; then
-    if [[ "$desktop_relay" == vnc && -f "$cursor_guard" &&
-          -n "$cursor_server_pid" ]] &&
-       grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" 2>/dev/null &&
-       grep -q 'UU cursor reader guard active' \
-           "$cursor_reader_guard_log" 2>/dev/null; then
+    for _ in {1..100}; do
+        relay_pid="$(pgrep -n -u "$UID" -x 'sdl-freerdp.exe' || true)"
+        cursor_server_pid="$(
+            pgrep -o -u "$UID" -f 'GameViewerServer\.exe' || true
+        )"
+        if cursor_reader_guard_ready &&
+           { [[ "$desktop_relay" == vnc ]] || cursor_relay_guard_ready; }; then
+            break
+        fi
+        sleep 0.05
+    done
+
+    if [[ "$desktop_relay" == vnc ]] && cursor_reader_guard_ready; then
         pass 'opt-in UU cursor reader guard is active; native VNC needs no relay DLL'
-    elif [[ "$desktop_relay" == rdp && -f "$cursor_guard" &&
-            -n "$relay_pid" && -n "$cursor_server_pid" ]] &&
-         grep -Fq "$cursor_guard" "/proc/$relay_pid/maps" 2>/dev/null &&
-         grep -Fq "$cursor_guard" "/proc/$cursor_server_pid/maps" 2>/dev/null &&
-         grep -q 'UU relay cursor guard active' \
-             "$cursor_guard_log" 2>/dev/null &&
-         grep -q 'UU cursor reader guard active' \
-             "$cursor_reader_guard_log" 2>/dev/null; then
+    elif [[ "$desktop_relay" == rdp ]] && cursor_reader_guard_ready &&
+         cursor_relay_guard_ready; then
         pass 'opt-in relay and UU cursor guards are active'
     else
         fail 'opt-in relay or UU cursor guard is missing or inactive'

--- a/src/winpr_sspi_shim.c
+++ b/src/winpr_sspi_shim.c
@@ -13,13 +13,13 @@ static SecurityFunctionTableA patched_a;
 static SecurityFunctionTableW patched_w;
 static SecurityFunctionTableA *original_a;
 static SecurityFunctionTableW *original_w;
-static const char negotiate_name[] = "Negotiate";
+#define SSPI_PACKAGE_NEGOTIATE_ID 3u
 
-static void fix_handle_name(PSecHandle handle)
+static void fix_handle_package_identity(PSecHandle handle)
 {
     if (handle != NULL && handle->dwLower != 0) {
-        /* WinPR stores handle pointers with every bit inverted. */
-        handle->dwUpper = ~((ULONG_PTR)negotiate_name);
+        /* WinPR 3.31 stores an inverted numeric package ID here. */
+        handle->dwUpper = ~((ULONG_PTR)SSPI_PACKAGE_NEGOTIATE_ID);
     }
 }
 
@@ -33,7 +33,7 @@ static SECURITY_STATUS WINAPI patched_acquire_credentials_a(
         get_key_argument, credential, expiry);
 
     if (status == SEC_E_OK)
-        fix_handle_name(credential);
+        fix_handle_package_identity(credential);
     return status;
 }
 
@@ -47,7 +47,7 @@ static SECURITY_STATUS WINAPI patched_acquire_credentials_w(
         get_key_argument, credential, expiry);
 
     if (status == SEC_E_OK)
-        fix_handle_name(credential);
+        fix_handle_package_identity(credential);
     return status;
 }
 
@@ -57,15 +57,15 @@ static SECURITY_STATUS WINAPI patched_initialize_context_a(
     PSecBufferDesc input, ULONG reserved2, PCtxtHandle new_context,
     PSecBufferDesc output, ULONG *context_attributes, PTimeStamp expiry)
 {
-    fix_handle_name(credential);
-    fix_handle_name(context);
+    fix_handle_package_identity(credential);
+    fix_handle_package_identity(context);
 
     SECURITY_STATUS status = original_a->InitializeSecurityContextA(
         credential, context, target, context_requirements, reserved1,
         data_representation, input, reserved2, new_context, output,
         context_attributes, expiry);
 
-    fix_handle_name(new_context);
+    fix_handle_package_identity(new_context);
     return status;
 }
 
@@ -75,15 +75,15 @@ static SECURITY_STATUS WINAPI patched_initialize_context_w(
     PSecBufferDesc input, ULONG reserved2, PCtxtHandle new_context,
     PSecBufferDesc output, ULONG *context_attributes, PTimeStamp expiry)
 {
-    fix_handle_name(credential);
-    fix_handle_name(context);
+    fix_handle_package_identity(credential);
+    fix_handle_package_identity(context);
 
     SECURITY_STATUS status = original_w->InitializeSecurityContextW(
         credential, context, target, context_requirements, reserved1,
         data_representation, input, reserved2, new_context, output,
         context_attributes, expiry);
 
-    fix_handle_name(new_context);
+    fix_handle_package_identity(new_context);
     return status;
 }
 

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -968,6 +968,13 @@ class RuntimeScriptTests(unittest.TestCase):
                 cwd=REPOSITORY,
             )
 
+    def test_ci_installs_the_terminal_proxy_cross_compiler(self):
+        workflow = (
+            REPOSITORY / ".github" / "workflows" / "validate.yml"
+        ).read_text()
+
+        self.assertIn("gcc-mingw-w64-x86-64-win32", workflow)
+
     def test_text_delay_migration_preserves_v010_behavior(self):
         resolver = REPOSITORY / "scripts" / "runtime-settings.sh"
 

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -763,6 +763,16 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertLess(reader_injection, injection)
         self.assertLess(injection, bootstrap)
         self.assertIn("pgrep -n -u \"$UID\" -x 'sdl-freerdp.exe'", verifier)
+        guard_enabled = verifier.index(
+            'if [[ "$cursor_guard_setting" == on ]]; then'
+        )
+        guard_wait = verifier.index("for _ in {1..100}; do", guard_enabled)
+        guard_result = verifier.index(
+            "opt-in relay and UU cursor guards are active", guard_wait
+        )
+        self.assertLess(guard_enabled, guard_wait)
+        self.assertLess(guard_wait, guard_result)
+        self.assertIn("sleep 0.05", verifier[guard_wait:guard_result])
 
     def test_phone_ime_unicode_input_is_normalized(self):
         bridge = (REPOSITORY / "src" / "uu_input_bridge.c").read_text()

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -669,6 +669,23 @@ class RuntimeScriptTests(unittest.TestCase):
         self.assertIn(".build-recipe", builder)
         self.assertIn("sha256sum -c .build-sha256", builder)
 
+    def test_freerdp_runtime_uses_the_retained_matching_revision(self):
+        builder = (REPOSITORY / "scripts" / "build-winpr.sh").read_text()
+        verifier = (REPOSITORY / "scripts" / "verify.sh").read_text()
+
+        self.assertIn("168925dac792142f6d0b66e7e2d568a3d439521c", builder)
+        self.assertIn("/2064/artifact/install/bin/sdl-freerdp.exe", builder)
+        expected = "b384347b6d0dd1e0c9912d18f5993b4e30643470e2a627e112debb34e8710762"
+        self.assertIn(expected, builder)
+        self.assertIn(expected, verifier)
+
+    def test_winpr_shim_uses_numeric_package_identity(self):
+        shim = (REPOSITORY / "src" / "winpr_sspi_shim.c").read_text()
+
+        self.assertIn("SSPI_PACKAGE_NEGOTIATE_ID 3u", shim)
+        self.assertIn("~((ULONG_PTR)SSPI_PACKAGE_NEGOTIATE_ID)", shim)
+        self.assertNotIn("static const char negotiate_name", shim)
+
     def test_clipboard_channel_is_enabled(self):
         launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
 


### PR DESCRIPTION
## Summary

- replace the pruned FreeRDP Windows Jenkins build 2038 with retained build 2064
- pin the separately built WinPR runtime to the exact matching FreeRDP revision, `168925dac792142f6d0b66e7e2d568a3d439521c`
- update the SSPI shim for the WinPR 3.31 inverted numeric package identity
- let verification wait up to five seconds for the opt-in cursor guard DLLs and activation logs, for both RDP and VNC relays
- install the MinGW compiler required by the existing native terminal proxy test in GitHub Actions

## Why

The pinned build 2038 artifact now returns HTTP 404 because older Jenkins nightlies are pruned. Moving only the executable is not sufficient: the accompanying MinGW-built `libwinpr3.dll` must match the executable revision, and WinPR 3.31 changed the private SSPI handle package identity from an inverted package-name pointer to an inverted numeric package ID.

Immediately after installation, cursor guard injection can also finish just after the general service readiness check. The verifier previously failed that otherwise healthy startup.

The latest upstream `main` also compiled the Windows terminal proxy during unit tests without installing its MinGW compiler in CI. This PR adds the missing runner dependency.

## Verification

- `python3 -m unittest discover -s tests -v` — 102 tests passed on the latest upstream `main`
- `./scripts/build-winpr.sh` — downloaded and hash-verified build 2064, then built `libwinpr3.dll` from the pinned revision
- `./scripts/build-compat.sh` — compatibility tools built successfully
- `.build-sha256` — all seven FreeRDP runtime artifacts passed
- Wine `/version` — `FreeRDP 3.31.1-dev0 (168925dac)`
- live Ubuntu 24.04 / GNOME 46 targeted check — `PASS opt-in relay and UU cursor guards are active`
- fork GitHub Actions validation — [all steps passed](https://github.com/yuechuuu/uu-remote-ubuntu-bridge/actions/runs/33752267482)