### PR TITLE
Add one-way GameViewer clipboard bridge for Wine X11 hosts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             gcc-mingw-w64-x86-64-win32 \
             wine wine64 wine64-tools \
-            xclip xvfb
+            x11-utils xclip xvfb
 
       - name: Run unit and documentation tests
         run: python3 -m unittest discover -s tests -v

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,13 +40,24 @@ jobs:
       - name: Compile Python
         run: python3 -m compileall -q scripts tests
 
-      - name: Install test compiler
+      - name: Install test compilers and isolated clipboard runtime
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64-win32
+          sudo apt-get install -y --no-install-recommends \
+            gcc-mingw-w64-x86-64-win32 \
+            wine wine64 wine64-tools \
+            xclip xvfb
 
       - name: Run unit and documentation tests
         run: python3 -m unittest discover -s tests -v
+
+      - name: Exercise the one-way controller clipboard boundary
+        env:
+          UURB_WINE_BIN: /usr/bin/wine
+          UURB_WINEBOOT_BIN: /usr/bin/wineboot
+          UURB_WINESERVER_BIN: /usr/bin/wineserver
+          WINEGCC: /usr/bin/winegcc
+        run: ./scripts/test-controller-clipboard.sh
 
       - name: Validate approved manifests
         run: python3 scripts/patch-gameviewer.py manifests

--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ desktop to Ubuntu while blocking the reverse target-to-private direction.
 `SendPrimary=0` avoids stale selected text, and the receive-only server plus
 `ServerCutText=0` prevent semantic target text from feeding back into the VNC
 viewer and being pasted again.
+
+Some UU controllers publish received desktop text only to GameViewer's Win32
+clipboard under Wine, without creating an X11 selection on the private
+display. For that case, a separate one-way companion accepts only
+`CF_UNICODETEXT` whose clipboard owner is `GameViewer.exe`, then sends the
+bounded UTF-8 value over an authenticated loopback socket to a native helper.
+The helper owns `CLIPBOARD` and `PRIMARY` on the selected physical X11 desktop;
+it never reads the host clipboard or emits a paste key. Images, rich text, and
+files are deliberately ignored. This preserves `ServerCutText=0` and the
+receive-only VNC boundary while allowing controller-to-Ubuntu text paste.
 See [semantic phone text and clipboard relay](docs/semantic-text-and-clipboard.md).
 
 On the validated XRDP workstation, the first live direct-UU run produced 256
@@ -303,6 +313,7 @@ touching the live desktop:
 ./scripts/test-rdp-semantic-text.sh
 ./scripts/test-x11-phone-text.sh
 ./scripts/test-x11-clipboard-text.sh
+./scripts/test-controller-clipboard.sh
 ```
 
 The companion mouse acceptance sends absolute movement and a complete click

--- a/README.md
+++ b/README.md
@@ -289,13 +289,18 @@ viewer and being pasted again.
 
 Some UU controllers publish received desktop text only to GameViewer's Win32
 clipboard under Wine, without creating an X11 selection on the private
-display. For that case, a separate one-way companion accepts only
-`CF_UNICODETEXT` whose clipboard owner is `GameViewer.exe`, then sends the
+display. On the explicit VNC/X11 fallback, a separate one-way companion
+accepts only new `CF_UNICODETEXT` changes whose clipboard owner remains exactly
+`GameViewer.exe` throughout the locked read. Existing clipboard content is
+baselined at companion startup and is not replayed. The companion sends the
 bounded UTF-8 value over an authenticated loopback socket to a native helper.
-The helper owns `CLIPBOARD` and `PRIMARY` on the selected physical X11 desktop;
-it never reads the host clipboard or emits a paste key. Images, rich text, and
-files are deliberately ignored. This preserves `ServerCutText=0` and the
-receive-only VNC boundary while allowing controller-to-Ubuntu text paste.
+The helper acknowledges only after foreground `xclip` children are confirmed
+as the new owners of both `CLIPBOARD` and `PRIMARY` on the selected physical
+X11 desktop. It never reads the host clipboard or emits a paste key. Images,
+rich text, and files are deliberately ignored. Socket operations have bounded
+deadlines, and either helper exiting causes the service to clean up and
+restart. This preserves `ServerCutText=0` and the receive-only VNC boundary
+while allowing controller-to-Ubuntu text paste.
 See [semantic phone text and clipboard relay](docs/semantic-text-and-clipboard.md).
 
 On the validated XRDP workstation, the first live direct-UU run produced 256

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,18 @@ The default RDP track uses a split semantic helper: it owns `CLIPBOARD` and
 the private Wine/FreeRDP display, and leaves every routine key and mouse event
 on RDP. Both helper sockets bind only to loopback and use a fresh per-start
 token.
+
+Controller clipboard text has a separate, strictly one-way path for Wine
+builds that do not mirror GameViewer's standard Win32 clipboard into the
+private X11 selection. A Wine companion polls the Win32 clipboard sequence,
+requires the owner process to be exactly `GameViewer.exe`, and accepts only
+bounded valid `CF_UNICODETEXT`. It normalizes Windows line endings and sends
+UTF-8 over a fresh-token loopback connection. The native listener validates
+the payload and owns `CLIPBOARD` plus `PRIMARY` on the selected host X11
+desktop. It has no host-clipboard read operation and performs no key
+injection, so it cannot create an Ubuntu-to-Wine feedback path. Non-text
+formats remain on the existing relay path and are not handled by this helper.
+
 The original request count is returned to UU only after the selected boundary
 accepts the complete request.
 The bridge keeps up to 2,048 input records from one provisional dictation call

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,14 +243,20 @@ token.
 
 Controller clipboard text has a separate, strictly one-way path for Wine
 builds that do not mirror GameViewer's standard Win32 clipboard into the
-private X11 selection. A Wine companion polls the Win32 clipboard sequence,
-requires the owner process to be exactly `GameViewer.exe`, and accepts only
-bounded valid `CF_UNICODETEXT`. It normalizes Windows line endings and sends
-UTF-8 over a fresh-token loopback connection. The native listener validates
-the payload and owns `CLIPBOARD` plus `PRIMARY` on the selected host X11
-desktop. It has no host-clipboard read operation and performs no key
-injection, so it cannot create an Ubuntu-to-Wine feedback path. Non-text
-formats remain on the existing relay path and are not handled by this helper.
+private X11 selection. It is enabled only for the explicit VNC/X11 desktop
+relay. A Wine companion baselines the Win32 clipboard sequence at startup, so
+pre-existing content is never replayed. For each later change it opens the
+clipboard, requires the owner process to remain exactly `GameViewer.exe`
+before and after the bounded `CF_UNICODETEXT` read, normalizes Windows line
+endings, and sends UTF-8 over a fresh-token loopback connection. The native
+listener uses bounded receive/send deadlines and acknowledges only after
+foreground `xclip` children are verified as the new owners of both
+`CLIPBOARD` and `PRIMARY` on the selected host X11 desktop. It has no
+host-clipboard read operation and performs no key injection, so it cannot
+create an Ubuntu-to-Wine feedback path. Both helpers are supervised as
+critical service children; their shutdown reaps the selection owners and a
+premature exit requests a clean full-service restart. Non-text formats remain
+on the existing relay path and are not handled by this helper.
 
 The original request count is returned to UU only after the selected boundary
 accepts the complete request.

--- a/docs/semantic-text-and-clipboard.md
+++ b/docs/semantic-text-and-clipboard.md
@@ -119,6 +119,16 @@ This channel is independent of phone-IME input. Copying text on a UU client
 uses the VNC clipboard relay; typing or dictating into UU's phone keyboard uses
 the adaptive broker route.
 
+Controllers that update only GameViewer's Win32 clipboard use an additional
+VNC/X11-only companion. It ignores the clipboard present at startup and
+accepts a later text change only while the locked clipboard owner remains
+`GameViewer.exe`. A token-authenticated loopback listener then installs the
+text on the physical X11 desktop. Success means foreground owner processes
+have been confirmed for both `CLIPBOARD` and `PRIMARY`; an `xclip` launch or
+ownership failure is rejected. The listener has one-second socket deadlines,
+and the launcher treats both companions as critical children so a crash
+cannot leave an untracked selection owner running.
+
 ## Isolated acceptance
 
 The test creates a temporary X display and Wine prefix. It does not type into
@@ -128,6 +138,7 @@ the logged-in desktop or inspect the user's clipboard:
 ./scripts/test-rdp-semantic-text.sh
 ./scripts/test-x11-clipboard-text.sh
 ./scripts/test-vnc-clipboard-relay.sh
+./scripts/test-controller-clipboard.sh
 ```
 
 The first pass creates separate clipboard and Wine relay displays. It proves
@@ -146,6 +157,11 @@ route=x11-clipboard-text error=0
 The third pass proves that a client cut-text packet reaches the isolated VNC
 server, reverse clipboard feedback is disabled, and a target-side Unicode
 paste remains exact without a loop.
+
+The controller-clipboard pass proves startup content is not replayed,
+non-GameViewer owners are ignored, Unicode multiline text reaches both X11
+selections exactly, a missing `xclip` is rejected, stalled clients time out,
+and helper shutdown leaves no owner child behind.
 
 Retain the established regression tests as separate boundaries:
 

--- a/install.sh
+++ b/install.sh
@@ -691,12 +691,15 @@ install -m 0755 \
     "$compat_build/uu-input-broker.exe" \
     "$compat_build/uu-injector.exe" \
     "$compat_build/uu-service-control.exe" \
+    "$compat_build/uu-wine-clipboard-bridge.exe" \
     "$compat_build/uu-terminal-proxy.exe" \
     "$wine_prefix/compat/"
 install -m 0755 "$compat_build/uu-network-filter.so" \
     "$wine_prefix/compat/uu-network-filter.so"
 install -m 0755 "$compat_build/uu-x11-input" \
     "$wine_prefix/compat/uu-x11-input"
+install -m 0755 "$compat_build/uu-x11-clipboard" \
+    "$wine_prefix/compat/uu-x11-clipboard"
 install -m 0755 "$compat_build/uu-terminal-bridge" \
     "$wine_prefix/compat/uu-terminal-bridge"
 install -m 0755 "$compat_build/uu-terminal-proxy.exe" \

--- a/scripts/build-compat.sh
+++ b/scripts/build-compat.sh
@@ -37,6 +37,10 @@ mkdir -p "$output_dir"
 "$cc" "${common[@]}" "${pe_link[@]}" -municode \
     -o "$output_dir/uu-service-control.exe" \
     "$repo_dir/src/uu_service_control.c" -ladvapi32
+"$cc" "${common[@]}" "${pe_link[@]}" -municode \
+    -I "$repo_dir/src" \
+    -o "$output_dir/uu-wine-clipboard-bridge.exe" \
+    "$repo_dir/src/uu_wine_clipboard_bridge.c" -lws2_32
 "$cc" "${common[@]}" "${pe_link[@]}" -I "$repo_dir/src" \
     -o "$output_dir/uu-terminal-proxy.exe" \
     "$repo_dir/src/uu_terminal_proxy.c" -lws2_32
@@ -53,6 +57,9 @@ mkdir -p "$output_dir"
     -o "$output_dir/uu-x11-input" \
     "$repo_dir/src/uu_x11_input.c" -ldl
 "$host_cc" "${common[@]}" -I "$repo_dir/src" \
+    -o "$output_dir/uu-x11-clipboard" \
+    "$repo_dir/src/uu_x11_clipboard.c"
+"$host_cc" "${common[@]}" -I "$repo_dir/src" \
     -o "$output_dir/uu-terminal-bridge" \
     "$repo_dir/src/uu_terminal_bridge.c" -lutil
 
@@ -62,12 +69,14 @@ mkdir -p "$output_dir"
     "$output_dir/uu-input-broker.exe" \
     "$output_dir/uu-injector.exe" \
     "$output_dir/uu-service-control.exe" \
+    "$output_dir/uu-wine-clipboard-bridge.exe" \
     "$output_dir/uu-terminal-proxy.exe" \
     "$output_dir/uu-healthd-stub.exe" \
     "$output_dir/winpr-sspi-shim.dll"
 "$host_strip" \
     "$output_dir/uu-network-filter.so" \
     "$output_dir/uu-x11-input" \
+    "$output_dir/uu-x11-clipboard" \
     "$output_dir/uu-terminal-bridge"
 
 rm -f "$output_dir/winlogon.exe" "$output_dir/winlogon.exe.so"

--- a/scripts/build-compat.sh
+++ b/scripts/build-compat.sh
@@ -58,7 +58,7 @@ mkdir -p "$output_dir"
     "$repo_dir/src/uu_x11_input.c" -ldl
 "$host_cc" "${common[@]}" -I "$repo_dir/src" \
     -o "$output_dir/uu-x11-clipboard" \
-    "$repo_dir/src/uu_x11_clipboard.c"
+    "$repo_dir/src/uu_x11_clipboard.c" -ldl
 "$host_cc" "${common[@]}" -I "$repo_dir/src" \
     -o "$output_dir/uu-terminal-bridge" \
     "$repo_dir/src/uu_terminal_bridge.c" -lutil

--- a/scripts/runtime-source-digest
+++ b/scripts/runtime-source-digest
@@ -35,14 +35,17 @@ runtime_files=(
     src/uu_injector.c
     src/uu_input_bridge.c
     src/uu_input_broker.c
+    src/uu_wine_clipboard_bridge.c
     src/uu_network_filter.c
     src/uu_service_control.c
     src/uu_terminal_bridge.c
     src/uu_terminal_proxy.c
     src/uu_x11_input.c
+    src/uu_x11_clipboard.c
     src/winlogon.c
     src/winpr_sspi_shim.c
     src/x11_input_protocol.h
+    src/x11_clipboard_protocol.h
     src/terminal_bridge_protocol.h
     systemd/uu-keyring-unlock.service
     systemd/uu-remote-bridge-unattended.conf

--- a/scripts/test-controller-clipboard.sh
+++ b/scripts/test-controller-clipboard.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/uurb-controller-clipboard.XXXXXX")"
+wine_prefix="$temporary_dir/wine"
+ready_file="$temporary_dir/x11-clipboard.port"
+token="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+host_xvfb_pid=""
+wine_xvfb_pid=""
+helper_pid=""
+companion_pid=""
+fixture_pid=""
+
+cleanup() {
+    local status=$?
+    local pid
+
+    trap - EXIT
+    for pid in "$fixture_pid" "$companion_pid" "$helper_pid" \
+        "$wine_xvfb_pid" "$host_xvfb_pid"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    if [[ -d "$wine_prefix" ]]; then
+        WINEPREFIX="$wine_prefix" /opt/wine-stable/bin/wineserver -k \
+            >/dev/null 2>&1 || true
+    fi
+    wait 2>/dev/null || true
+    if [[ "${UURB_KEEP_TEST_TMP:-0}" == 1 || "$status" -ne 0 ]]; then
+        printf 'isolated test artifacts: %s\n' "$temporary_dir" >&2
+    elif [[ "$temporary_dir" == "${TMPDIR:-/tmp}/uurb-controller-clipboard."* ]]; then
+        rm -rf -- "$temporary_dir"
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+
+for command in flock timeout Xvfb xclip xdpyinfo \
+    x86_64-w64-mingw32-gcc /opt/wine-stable/bin/wine \
+    /opt/wine-stable/bin/wineboot; do
+    command -v "$command" >/dev/null 2>&1 || {
+        printf 'missing controller-clipboard test command: %s\n' "$command" >&2
+        exit 1
+    }
+done
+
+exec 9>"${TMPDIR:-/tmp}/uurb-isolated-x-display.lock"
+flock -x 9
+host_display=""
+wine_display=""
+for number in {88..99}; do
+    if [[ ! -S "/tmp/.X11-unix/X$number" ]]; then
+        if [[ -z "$host_display" ]]; then
+            host_display=":$number"
+        else
+            wine_display=":$number"
+            break
+        fi
+    fi
+done
+[[ -n "$host_display" && -n "$wine_display" ]] || {
+    printf 'two free isolated X displays are required in :88..:99\n' >&2
+    exit 1
+}
+
+"$repo_dir/scripts/build-compat.sh" "$temporary_dir/compat" >/dev/null
+x86_64-w64-mingw32-gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -municode -mwindows \
+    -DUURB_FIXTURE_TEXT='L"Mac controller 中文\r\nsecond line"' \
+    -o "$temporary_dir/GameViewer.exe" \
+    "$repo_dir/tests/probes/uu_controller_clipboard_fixture.c" -luser32
+x86_64-w64-mingw32-gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -municode -mwindows \
+    -DUURB_FIXTURE_TEXT='L"must not leave OtherApp"' \
+    -o "$temporary_dir/OtherApp.exe" \
+    "$repo_dir/tests/probes/uu_controller_clipboard_fixture.c" -luser32
+
+Xvfb "$host_display" -screen 0 800x600x24 -ac -nolisten tcp \
+    >"$temporary_dir/host-xvfb.log" 2>&1 &
+host_xvfb_pid=$!
+Xvfb "$wine_display" -screen 0 800x600x24 -ac -nolisten tcp \
+    >"$temporary_dir/wine-xvfb.log" 2>&1 &
+wine_xvfb_pid=$!
+for _ in {1..50}; do
+    if DISPLAY="$host_display" timeout 0.5 xdpyinfo >/dev/null 2>&1 9>&- &&
+       DISPLAY="$wine_display" timeout 0.5 xdpyinfo >/dev/null 2>&1 9>&-; then
+        break
+    fi
+    sleep 0.1
+done
+DISPLAY="$host_display" timeout 5 xdpyinfo >/dev/null 9>&-
+DISPLAY="$wine_display" timeout 5 xdpyinfo >/dev/null 9>&-
+flock -u 9
+
+DISPLAY="$host_display" UURB_X11_CLIPBOARD_TOKEN="$token" \
+    "$temporary_dir/compat/uu-x11-clipboard" --ready-file "$ready_file" \
+    >"$temporary_dir/x11-clipboard.log" 2>&1 &
+helper_pid=$!
+for _ in {1..50}; do
+    [[ -s "$ready_file" ]] && break
+    sleep 0.1
+done
+[[ -s "$ready_file" ]]
+port="$(tr -d '[:space:]' <"$ready_file")"
+
+DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    /opt/wine-stable/bin/wineboot -u >/dev/null 2>&1
+DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    UURB_X11_CLIPBOARD_PORT="$port" UURB_X11_CLIPBOARD_TOKEN="$token" \
+    /opt/wine-stable/bin/wine \
+    "$temporary_dir/compat/uu-wine-clipboard-bridge.exe" \
+    >"$temporary_dir/companion.log" 2>&1 &
+companion_pid=$!
+sleep 0.2
+
+DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    /opt/wine-stable/bin/wine "$temporary_dir/GameViewer.exe" &
+fixture_pid=$!
+expected=$'Mac controller 中文\nsecond line'
+observed=""
+for _ in {1..80}; do
+    observed="$(DISPLAY="$host_display" timeout 0.2 \
+        xclip -selection clipboard -out 2>/dev/null || true)"
+    [[ "$observed" == "$expected" ]] && break
+    sleep 0.05
+done
+[[ "$observed" == "$expected" ]] || {
+    printf 'GameViewer-owned Unicode text did not reach X11 exactly\n' >&2
+    exit 1
+}
+wait "$fixture_pid"
+fixture_pid=""
+
+DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    /opt/wine-stable/bin/wine "$temporary_dir/OtherApp.exe" &
+fixture_pid=$!
+sleep 0.5
+observed="$(DISPLAY="$host_display" timeout 0.5 \
+    xclip -selection clipboard -out 2>/dev/null || true)"
+[[ "$observed" == "$expected" ]] || {
+    printf 'non-GameViewer clipboard owner crossed the one-way boundary\n' >&2
+    exit 1
+}
+wait "$fixture_pid"
+fixture_pid=""
+
+printf 'controller-clipboard=GameViewer Unicode multiline exact\n'
+printf 'owner-filter=non-GameViewer ignored\n'
+printf 'direction=Wine-to-X11-only\n'

--- a/scripts/test-controller-clipboard.sh
+++ b/scripts/test-controller-clipboard.sh
@@ -78,12 +78,12 @@ done
 
 "$repo_dir/scripts/build-compat.sh" "$temporary_dir/compat" >/dev/null
 x86_64-w64-mingw32-gcc -std=c11 -O2 -Wall -Wextra -Werror \
-    -municode -mwindows \
+    -municode \
     -DUURB_FIXTURE_TEXT='L"Mac controller 中文\r\nsecond line"' \
     -o "$temporary_dir/GameViewer.exe" \
     "$repo_dir/tests/probes/uu_controller_clipboard_fixture.c" -luser32
 x86_64-w64-mingw32-gcc -std=c11 -O2 -Wall -Wextra -Werror \
-    -municode -mwindows \
+    -municode \
     -DUURB_FIXTURE_TEXT='L"must not leave OtherApp"' \
     -o "$temporary_dir/OtherApp.exe" \
     "$repo_dir/tests/probes/uu_controller_clipboard_fixture.c" -luser32
@@ -142,9 +142,16 @@ exec 8>&- 8<&-
 # the baseline, not an event to forward to the host.
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    "$wine_bin" "$temporary_dir/GameViewer.exe" &
+    "$wine_bin" "$temporary_dir/GameViewer.exe" \
+    >"$temporary_dir/startup-fixture.log" 2>&1 &
 fixture_pid=$!
-sleep 0.4
+for _ in {1..100}; do
+    grep -q 'fixture clipboard ready' \
+        "$temporary_dir/startup-fixture.log" 2>/dev/null && break
+    kill -0 "$fixture_pid" 2>/dev/null || break
+    sleep 0.05
+done
+grep -q 'fixture clipboard ready' "$temporary_dir/startup-fixture.log"
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
     UURB_X11_CLIPBOARD_PORT="$port" UURB_X11_CLIPBOARD_TOKEN="$token" \
@@ -171,8 +178,16 @@ fixture_pid=""
 
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    "$wine_bin" "$temporary_dir/GameViewer.exe" &
+    "$wine_bin" "$temporary_dir/GameViewer.exe" \
+    >"$temporary_dir/gameviewer-fixture.log" 2>&1 &
 fixture_pid=$!
+for _ in {1..100}; do
+    grep -q 'fixture clipboard ready' \
+        "$temporary_dir/gameviewer-fixture.log" 2>/dev/null && break
+    kill -0 "$fixture_pid" 2>/dev/null || break
+    sleep 0.05
+done
+grep -q 'fixture clipboard ready' "$temporary_dir/gameviewer-fixture.log"
 expected=$'Mac controller 中文\nsecond line'
 observed=""
 for _ in {1..80}; do
@@ -196,8 +211,16 @@ fixture_pid=""
 
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    "$wine_bin" "$temporary_dir/OtherApp.exe" &
+    "$wine_bin" "$temporary_dir/OtherApp.exe" \
+    >"$temporary_dir/other-fixture.log" 2>&1 &
 fixture_pid=$!
+for _ in {1..100}; do
+    grep -q 'fixture clipboard ready' \
+        "$temporary_dir/other-fixture.log" 2>/dev/null && break
+    kill -0 "$fixture_pid" 2>/dev/null || break
+    sleep 0.05
+done
+grep -q 'fixture clipboard ready' "$temporary_dir/other-fixture.log"
 sleep 0.5
 observed="$(DISPLAY="$host_display" timeout 0.5 \
     xclip -selection clipboard -out 2>/dev/null || true)"

--- a/scripts/test-controller-clipboard.sh
+++ b/scripts/test-controller-clipboard.sh
@@ -7,11 +7,16 @@ temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/uurb-controller-clipboard.XXXXXX")"
 wine_prefix="$temporary_dir/wine"
 ready_file="$temporary_dir/x11-clipboard.port"
 token="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+wine_bin="${UURB_WINE_BIN:-/opt/wine-stable/bin/wine}"
+wineboot_bin="${UURB_WINEBOOT_BIN:-/opt/wine-stable/bin/wineboot}"
+wineserver_bin="${UURB_WINESERVER_BIN:-/opt/wine-stable/bin/wineserver}"
 host_xvfb_pid=""
 wine_xvfb_pid=""
 helper_pid=""
 companion_pid=""
 fixture_pid=""
+seed_pid=""
+broken_helper_pid=""
 
 cleanup() {
     local status=$?
@@ -19,15 +24,20 @@ cleanup() {
 
     trap - EXIT
     for pid in "$fixture_pid" "$companion_pid" "$helper_pid" \
-        "$wine_xvfb_pid" "$host_xvfb_pid"; do
+        "$broken_helper_pid" "$seed_pid"; do
         if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
             kill "$pid" 2>/dev/null || true
         fi
     done
     if [[ -d "$wine_prefix" ]]; then
-        WINEPREFIX="$wine_prefix" /opt/wine-stable/bin/wineserver -k \
+        WINEPREFIX="$wine_prefix" "$wineserver_bin" -k \
             >/dev/null 2>&1 || true
     fi
+    for pid in "$wine_xvfb_pid" "$host_xvfb_pid"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
     wait 2>/dev/null || true
     if [[ "${UURB_KEEP_TEST_TMP:-0}" == 1 || "$status" -ne 0 ]]; then
         printf 'isolated test artifacts: %s\n' "$temporary_dir" >&2
@@ -38,9 +48,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for command in flock timeout Xvfb xclip xdpyinfo \
-    x86_64-w64-mingw32-gcc /opt/wine-stable/bin/wine \
-    /opt/wine-stable/bin/wineboot; do
+for command in flock timeout Xvfb xclip xdpyinfo gcc pgrep python3 \
+    x86_64-w64-mingw32-gcc "$wine_bin" "$wineboot_bin" \
+    "$wineserver_bin"; do
     command -v "$command" >/dev/null 2>&1 || {
         printf 'missing controller-clipboard test command: %s\n' "$command" >&2
         exit 1
@@ -108,19 +118,60 @@ port="$(tr -d '[:space:]' <"$ready_file")"
 
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    /opt/wine-stable/bin/wineboot -u >/dev/null 2>&1
+    "$wineboot_bin" -u >/dev/null 2>&1
+
+sentinel='existing host clipboard'
+printf '%s' "$sentinel" | DISPLAY="$host_display" \
+    xclip -selection clipboard -in -loops 0 -verbose \
+    >"$temporary_dir/seed-xclip.log" 2>&1 &
+seed_pid=$!
+for _ in {1..40}; do
+    observed="$(DISPLAY="$host_display" timeout 0.2 \
+        xclip -selection clipboard -out 2>/dev/null || true)"
+    [[ "$observed" == "$sentinel" ]] && break
+    sleep 0.05
+done
+[[ "$observed" == "$sentinel" ]]
+
+# A connected client that sends no handshake must not monopolize the helper.
+exec 8<>"/dev/tcp/127.0.0.1/$port"
+sleep 1.2
+exec 8>&- 8<&-
+
+# Clipboard content already owned by GameViewer when the companion starts is
+# the baseline, not an event to forward to the host.
+DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
+    WINEDLLOVERRIDES='mscoree,mshtml=' \
+    "$wine_bin" "$temporary_dir/GameViewer.exe" &
+fixture_pid=$!
+sleep 0.4
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
     UURB_X11_CLIPBOARD_PORT="$port" UURB_X11_CLIPBOARD_TOKEN="$token" \
-    /opt/wine-stable/bin/wine \
+    "$wine_bin" \
     "$temporary_dir/compat/uu-wine-clipboard-bridge.exe" \
     >"$temporary_dir/companion.log" 2>&1 &
 companion_pid=$!
-sleep 0.2
+for _ in {1..80}; do
+    grep -q 'Wine clipboard companion ready' \
+        "$temporary_dir/companion.log" 2>/dev/null && break
+    kill -0 "$companion_pid" 2>/dev/null || break
+    sleep 0.05
+done
+grep -q 'Wine clipboard companion ready' "$temporary_dir/companion.log"
+sleep 0.25
+observed="$(DISPLAY="$host_display" timeout 0.5 \
+    xclip -selection clipboard -out 2>/dev/null || true)"
+[[ "$observed" == "$sentinel" ]] || {
+    printf 'clipboard content present before companion startup was replayed\n' >&2
+    exit 1
+}
+wait "$fixture_pid"
+fixture_pid=""
 
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    /opt/wine-stable/bin/wine "$temporary_dir/GameViewer.exe" &
+    "$wine_bin" "$temporary_dir/GameViewer.exe" &
 fixture_pid=$!
 expected=$'Mac controller 中文\nsecond line'
 observed=""
@@ -134,12 +185,18 @@ done
     printf 'GameViewer-owned Unicode text did not reach X11 exactly\n' >&2
     exit 1
 }
+observed_primary="$(DISPLAY="$host_display" timeout 0.5 \
+    xclip -selection primary -out 2>/dev/null || true)"
+[[ "$observed_primary" == "$expected" ]] || {
+    printf 'GameViewer-owned Unicode text did not reach PRIMARY exactly\n' >&2
+    exit 1
+}
 wait "$fixture_pid"
 fixture_pid=""
 
 DISPLAY="$wine_display" WINEPREFIX="$wine_prefix" WINEDEBUG=-all \
     WINEDLLOVERRIDES='mscoree,mshtml=' \
-    /opt/wine-stable/bin/wine "$temporary_dir/OtherApp.exe" &
+    "$wine_bin" "$temporary_dir/OtherApp.exe" &
 fixture_pid=$!
 sleep 0.5
 observed="$(DISPLAY="$host_display" timeout 0.5 \
@@ -151,6 +208,90 @@ observed="$(DISPLAY="$host_display" timeout 0.5 \
 wait "$fixture_pid"
 fixture_pid=""
 
+mapfile -t owner_pids < <(pgrep -P "$helper_pid" -x xclip || true)
+[[ "${#owner_pids[@]}" -eq 2 ]] || {
+    printf 'native helper does not supervise exactly two xclip owners\n' >&2
+    exit 1
+}
+kill "$helper_pid"
+wait "$helper_pid"
+helper_pid=""
+for pid in "${owner_pids[@]}"; do
+    for _ in {1..40}; do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.05
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        printf 'xclip owner survived native-helper shutdown: %s\n' "$pid" >&2
+        exit 1
+    fi
+done
+
+# A missing or failed xclip must produce an owner error and preserve the
+# current host selection rather than acknowledging data it did not install.
+broken_ready_file="$temporary_dir/broken-x11-clipboard.port"
+broken_token="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -DUURB_XCLIP_PATH='"/nonexistent/uurb-xclip"' \
+    -I "$repo_dir/src" -o "$temporary_dir/uu-x11-clipboard-broken" \
+    "$repo_dir/src/uu_x11_clipboard.c" -ldl
+printf '%s' "$sentinel" | DISPLAY="$host_display" \
+    xclip -selection clipboard -in -loops 0 -verbose \
+    >"$temporary_dir/broken-seed-xclip.log" 2>&1 &
+seed_pid=$!
+DISPLAY="$host_display" UURB_X11_CLIPBOARD_TOKEN="$broken_token" \
+    "$temporary_dir/uu-x11-clipboard-broken" \
+    --ready-file "$broken_ready_file" \
+    >"$temporary_dir/broken-x11-clipboard.log" 2>&1 &
+broken_helper_pid=$!
+for _ in {1..50}; do
+    [[ -s "$broken_ready_file" ]] && break
+    sleep 0.1
+done
+[[ -s "$broken_ready_file" ]]
+broken_port="$(tr -d '[:space:]' <"$broken_ready_file")"
+python3 - "$broken_port" "$broken_token" <<'PY'
+import socket
+import struct
+import sys
+
+magic = 0x43425555
+port = int(sys.argv[1])
+token = sys.argv[2].encode("ascii")
+
+def receive_exact(connection, size):
+    chunks = []
+    while size:
+        chunk = connection.recv(size)
+        if not chunk:
+            raise SystemExit("clipboard helper closed before its response")
+        chunks.append(chunk)
+        size -= len(chunk)
+    return b"".join(chunks)
+
+with socket.create_connection(("127.0.0.1", port), timeout=2) as connection:
+    connection.sendall(struct.pack("<II64s", magic, 1, token))
+    assert struct.unpack("<IIII", receive_exact(connection, 16)) == (magic, 0, 1, 0)
+    payload = b"must not be acknowledged"
+    connection.sendall(struct.pack("<IIII", magic, 77, len(payload), 0) + payload)
+    assert struct.unpack("<IIII", receive_exact(connection, 16)) == (
+        magic, 77, 0, 0x3003
+    )
+PY
+observed="$(DISPLAY="$host_display" timeout 0.5 \
+    xclip -selection clipboard -out 2>/dev/null || true)"
+[[ "$observed" == "$sentinel" ]] || {
+    printf 'failed xclip launch displaced the host clipboard\n' >&2
+    exit 1
+}
+kill "$broken_helper_pid"
+wait "$broken_helper_pid"
+broken_helper_pid=""
+
 printf 'controller-clipboard=GameViewer Unicode multiline exact\n'
 printf 'owner-filter=non-GameViewer ignored\n'
+printf 'startup-baseline=existing content ignored\n'
+printf 'selection-owners=CLIPBOARD and PRIMARY confirmed\n'
+printf 'failure-mode=xclip failure rejected\n'
+printf 'lifecycle=deadlines bounded and owner children reaped\n'
 printf 'direction=Wine-to-X11-only\n'

--- a/scripts/uu-remote-bridge
+++ b/scripts/uu-remote-bridge
@@ -967,6 +967,9 @@ start_x11_input_helper() {
 start_x11_clipboard_helper() {
     local selected_xauthority
 
+    if [[ "$desktop_relay" != vnc ]]; then
+        return 0
+    fi
     if [[ ! -x "$x11_clipboard_helper" ]]; then
         log 'The optional one-way X11 clipboard helper is missing; retaining the existing clipboard behavior.'
         return 0
@@ -1643,6 +1646,8 @@ for optional_pid in \
     "$desktop_x11vnc_pid" \
     "$vncviewer_pid" \
     "$x11_input_pid" \
+    "$x11_clipboard_pid" \
+    "$wine_clipboard_bridge_pid" \
     "$terminal_bridge_pid"; do
     if [[ -n "$optional_pid" ]]; then
         critical_pids+=("$optional_pid")

--- a/scripts/uu-remote-bridge
+++ b/scripts/uu-remote-bridge
@@ -146,6 +146,8 @@ cursor_reader_guard_log="$WINEPREFIX/drive_c/users/$bridge_user/AppData/Local/Te
 input_bridge_dll="$compat_dir/uu-input-bridge.dll"
 input_broker_exe="$compat_dir/uu-input-broker.exe"
 x11_input_helper="$compat_dir/uu-x11-input"
+x11_clipboard_helper="$compat_dir/uu-x11-clipboard"
+wine_clipboard_bridge_exe="$compat_dir/uu-wine-clipboard-bridge.exe"
 network_filter="$compat_dir/uu-network-filter.so"
 input_injector_exe="$compat_dir/uu-injector.exe"
 service_control_exe="$compat_dir/uu-service-control.exe"
@@ -156,6 +158,7 @@ terminal_proxy_exe="$uu_app_dir/bin/powershell.exe"
 terminal_config_file="$uu_app_dir/bin/uu-terminal-bridge.runtime"
 xauth_file="$runtime_dir/Xauthority"
 x11_input_ready_file="$runtime_dir/x11-input.port"
+x11_clipboard_ready_file="$runtime_dir/x11-clipboard.port"
 terminal_ready_file="$runtime_dir/terminal.port"
 private_display_file="$runtime_dir/private-display"
 console_focus_file="$runtime_dir/console-focus"
@@ -176,6 +179,8 @@ vncviewer_pid=""
 winlogon_pid=""
 input_broker_pid=""
 x11_input_pid=""
+x11_clipboard_pid=""
+wine_clipboard_bridge_pid=""
 terminal_bridge_pid=""
 server_supervisor_pid=""
 grd_user_service_was_active=false
@@ -194,6 +199,8 @@ desktop_vnc_port=""
 cursor_size=""
 x11_input_port=""
 x11_input_token=""
+x11_clipboard_port=""
+x11_clipboard_token=""
 terminal_bridge_port=""
 terminal_bridge_token=""
 
@@ -396,6 +403,8 @@ cleanup() {
         "$server_supervisor_pid" \
         "$input_broker_pid" \
         "$x11_input_pid" \
+        "$wine_clipboard_bridge_pid" \
+        "$x11_clipboard_pid" \
         "$terminal_bridge_pid" \
         "$winlogon_pid" \
         "$vncviewer_pid" \
@@ -415,6 +424,8 @@ cleanup() {
             "$server_supervisor_pid" \
             "$input_broker_pid" \
             "$x11_input_pid" \
+            "$wine_clipboard_bridge_pid" \
+            "$x11_clipboard_pid" \
             "$terminal_bridge_pid" \
             "$winlogon_pid" \
             "$vncviewer_pid" \
@@ -436,6 +447,8 @@ cleanup() {
         "$server_supervisor_pid" \
         "$input_broker_pid" \
         "$x11_input_pid" \
+        "$wine_clipboard_bridge_pid" \
+        "$x11_clipboard_pid" \
         "$terminal_bridge_pid" \
         "$winlogon_pid" \
         "$vncviewer_pid" \
@@ -472,6 +485,7 @@ cleanup() {
     rm -f \
         "$xauth_file" \
         "$x11_input_ready_file" \
+        "$x11_clipboard_ready_file" \
         "$terminal_ready_file" \
         "$private_display_file" \
         "$console_focus_file"
@@ -950,6 +964,82 @@ start_x11_input_helper() {
     rm -f "$x11_input_ready_file"
 }
 
+start_x11_clipboard_helper() {
+    local selected_xauthority
+
+    if [[ ! -x "$x11_clipboard_helper" ]]; then
+        log 'The optional one-way X11 clipboard helper is missing; retaining the existing clipboard behavior.'
+        return 0
+    fi
+    if [[ "$desktop_session_type" != x11 || -z "$desktop_display" ]]; then
+        log "One-way Mac clipboard forwarding requires the selected physical X11 desktop; selected ${desktop_session_type:-unknown}."
+        return 0
+    fi
+    selected_xauthority="$desktop_xauthority"
+    if [[ -z "$selected_xauthority" && -f "$HOME/.Xauthority" ]]; then
+        selected_xauthority="$HOME/.Xauthority"
+    fi
+    if ! /usr/bin/env DISPLAY="$desktop_display" \
+        XAUTHORITY="$selected_xauthority" \
+        /usr/bin/xdpyinfo >/dev/null 2>&1; then
+        log 'The target desktop clipboard authorization could not be verified; retaining the existing clipboard behavior.'
+        return 0
+    fi
+
+    rm -f "$x11_clipboard_ready_file"
+    x11_clipboard_token="$(/usr/bin/openssl rand -hex 32)"
+    /usr/bin/env \
+        DISPLAY="$desktop_display" \
+        XAUTHORITY="$selected_xauthority" \
+        UURB_X11_CLIPBOARD_TOKEN="$x11_clipboard_token" \
+        "$x11_clipboard_helper" --ready-file "$x11_clipboard_ready_file" \
+        >>"$state_dir/x11-clipboard.log" 2>&1 &
+    x11_clipboard_pid=$!
+
+    for _ in {1..50}; do
+        if [[ -s "$x11_clipboard_ready_file" ]] && \
+           kill -0 "$x11_clipboard_pid" >/dev/null 2>&1; then
+            read -r x11_clipboard_port <"$x11_clipboard_ready_file"
+            if [[ "$x11_clipboard_port" =~ ^[1-9][0-9]{0,4}$ ]] && \
+               ((x11_clipboard_port <= 65535)); then
+                log "One-way Wine-to-$desktop_display text clipboard helper is ready."
+                return 0
+            fi
+        fi
+        if ! kill -0 "$x11_clipboard_pid" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.1
+    done
+
+    log 'The optional one-way X11 clipboard helper did not become ready; retaining the existing clipboard behavior.'
+    kill "$x11_clipboard_pid" >/dev/null 2>&1 || true
+    x11_clipboard_pid=""
+    x11_clipboard_port=""
+    x11_clipboard_token=""
+    rm -f "$x11_clipboard_ready_file"
+}
+
+start_wine_clipboard_bridge() {
+    if [[ -z "$x11_clipboard_port" ||
+          ! -f "$wine_clipboard_bridge_exe" ]]; then
+        return 0
+    fi
+    /usr/bin/env \
+        "UURB_X11_CLIPBOARD_PORT=$x11_clipboard_port" \
+        "UURB_X11_CLIPBOARD_TOKEN=$x11_clipboard_token" \
+        /opt/wine-stable/bin/wine "$wine_clipboard_bridge_exe" \
+        >>"$state_dir/wine-clipboard-bridge.log" 2>&1 &
+    wine_clipboard_bridge_pid=$!
+    sleep 0.2
+    if ! kill -0 "$wine_clipboard_bridge_pid" >/dev/null 2>&1; then
+        log 'The optional Wine clipboard companion exited during startup; retaining the existing clipboard behavior.'
+        wine_clipboard_bridge_pid=""
+        return 0
+    fi
+    log 'Mac/UU clipboard forwarding is active: GameViewer CF_UNICODETEXT -> physical X11 only.'
+}
+
 start_terminal_bridge() {
     local config_temporary
 
@@ -1072,6 +1162,7 @@ mv "$private_display_tmp" "$private_display_file"
 /usr/bin/openbox >>"$state_dir/openbox.log" 2>&1 &
 openbox_pid=$!
 start_x11_input_helper
+start_x11_clipboard_helper
 
 if [[ "$desktop_relay" == rdp && ! -f "$freerdp_exe" ]]; then
     log 'The Windows FreeRDP client is missing from the Wine prefix.'
@@ -1084,6 +1175,7 @@ fi
 
 if [[ ! -f "$input_bridge_dll" || ! -f "$input_broker_exe" ||
       ! -f "$input_injector_exe" || ! -f "$service_control_exe" ||
+      ! -f "$wine_clipboard_bridge_exe" || ! -x "$x11_clipboard_helper" ||
       ! -x "$terminal_bridge_helper" ||
       ! -f "$terminal_proxy_compat" ||
       ! -f "$terminal_proxy_exe" ]] ||
@@ -1191,6 +1283,7 @@ if ! /opt/wine-stable/bin/wine "$input_injector_exe" \
     log 'Could not inject the UU input compatibility bridge.'
     exit 1
 fi
+start_wine_clipboard_bridge
 if [[ "$cursor_guard_setting" == on ]]; then
     cursor_guard_windows_path="$(
         /opt/wine-stable/bin/winepath -w "$cursor_guard_dll"
@@ -1534,7 +1627,7 @@ supervise_server() {
 supervise_server "$server_pid" &
 server_supervisor_pid=$!
 
-log "UU Remote and the $desktop_relay desktop relay share DISPLAY=$DISPLAY; physical keyboard route=$active_keyboard_route; semantic phone text helper=$([[ -n "$x11_input_port" ]] && printf active || printf unavailable)."
+log "UU Remote and the $desktop_relay desktop relay share DISPLAY=$DISPLAY; physical keyboard route=$active_keyboard_route; semantic phone text helper=$([[ -n "$x11_input_port" ]] && printf active || printf unavailable); one-way Mac clipboard=$([[ -n "$wine_clipboard_bridge_pid" ]] && printf active || printf unavailable)."
 
 set +e
 critical_pids=(

--- a/src/uu_wine_clipboard_bridge.c
+++ b/src/uu_wine_clipboard_bridge.c
@@ -1,0 +1,298 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "x11_clipboard_protocol.h"
+
+#define UURB_CLIPBOARD_POLL_MS 125UL
+#define UURB_CLIPBOARD_MAX_UNITS 1048576UL
+
+static SOCKET clipboard_socket = INVALID_SOCKET;
+static BOOL winsock_initialized;
+static unsigned short clipboard_port;
+static char clipboard_token[UURB_X11_CLIPBOARD_TOKEN_SIZE + 1];
+
+static void close_clipboard_socket(void)
+{
+    if (clipboard_socket != INVALID_SOCKET) {
+        closesocket(clipboard_socket);
+        clipboard_socket = INVALID_SOCKET;
+    }
+}
+
+static BOOL socket_write_all(SOCKET socket_handle, const void *buffer, int size)
+{
+    const char *position = (const char *)buffer;
+
+    while (size > 0) {
+        int written = send(socket_handle, position, size, 0);
+
+        if (written == SOCKET_ERROR || written == 0)
+            return FALSE;
+        position += written;
+        size -= written;
+    }
+    return TRUE;
+}
+
+static BOOL socket_read_all(SOCKET socket_handle, void *buffer, int size)
+{
+    char *position = (char *)buffer;
+
+    while (size > 0) {
+        int received = recv(socket_handle, position, size, 0);
+
+        if (received == SOCKET_ERROR || received == 0)
+            return FALSE;
+        position += received;
+        size -= received;
+    }
+    return TRUE;
+}
+
+static BOOL configure_bridge(void)
+{
+    wchar_t port_value[16];
+    wchar_t token_value[UURB_X11_CLIPBOARD_TOKEN_SIZE + 1];
+    wchar_t *end = NULL;
+    DWORD port_length;
+    DWORD token_length;
+    unsigned long parsed_port;
+    DWORD index;
+
+    port_length = GetEnvironmentVariableW(L"UURB_X11_CLIPBOARD_PORT",
+                                           port_value, ARRAYSIZE(port_value));
+    token_length = GetEnvironmentVariableW(L"UURB_X11_CLIPBOARD_TOKEN",
+                                            token_value, ARRAYSIZE(token_value));
+    if (port_length == 0 || port_length >= ARRAYSIZE(port_value) ||
+        token_length != UURB_X11_CLIPBOARD_TOKEN_SIZE)
+        return FALSE;
+    parsed_port = wcstoul(port_value, &end, 10);
+    if (end == port_value || *end != L'\0' || parsed_port == 0 ||
+        parsed_port > 65535)
+        return FALSE;
+    for (index = 0; index < UURB_X11_CLIPBOARD_TOKEN_SIZE; index++) {
+        wchar_t character = token_value[index];
+
+        if (!((character >= L'0' && character <= L'9') ||
+              (character >= L'a' && character <= L'f') ||
+              (character >= L'A' && character <= L'F')))
+            return FALSE;
+        clipboard_token[index] = (char)character;
+    }
+    clipboard_token[UURB_X11_CLIPBOARD_TOKEN_SIZE] = '\0';
+    clipboard_port = (unsigned short)parsed_port;
+    return TRUE;
+}
+
+static BOOL connect_clipboard_listener(void)
+{
+    struct sockaddr_in address;
+    uurb_x11_clipboard_handshake handshake;
+    uurb_x11_clipboard_response response;
+    DWORD timeout_ms = 1000;
+    WSADATA data;
+
+    if (clipboard_socket != INVALID_SOCKET)
+        return TRUE;
+    if (!winsock_initialized) {
+        if (WSAStartup(MAKEWORD(2, 2), &data) != 0)
+            return FALSE;
+        winsock_initialized = TRUE;
+    }
+    clipboard_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (clipboard_socket == INVALID_SOCKET)
+        return FALSE;
+    setsockopt(clipboard_socket, SOL_SOCKET, SO_SNDTIMEO,
+               (const char *)&timeout_ms, sizeof(timeout_ms));
+    setsockopt(clipboard_socket, SOL_SOCKET, SO_RCVTIMEO,
+               (const char *)&timeout_ms, sizeof(timeout_ms));
+    ZeroMemory(&address, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(clipboard_port);
+    if (connect(clipboard_socket, (struct sockaddr *)&address,
+                sizeof(address)) == SOCKET_ERROR) {
+        close_clipboard_socket();
+        return FALSE;
+    }
+    ZeroMemory(&handshake, sizeof(handshake));
+    handshake.magic = UURB_X11_CLIPBOARD_MAGIC;
+    handshake.version = UURB_X11_CLIPBOARD_VERSION;
+    memcpy(handshake.token, clipboard_token, UURB_X11_CLIPBOARD_TOKEN_SIZE);
+    if (!socket_write_all(clipboard_socket, &handshake, sizeof(handshake)) ||
+        !socket_read_all(clipboard_socket, &response, sizeof(response)) ||
+        response.magic != UURB_X11_CLIPBOARD_MAGIC || response.sequence != 0 ||
+        response.result != 1 || response.error != 0) {
+        close_clipboard_socket();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL owner_is_gameviewer(void)
+{
+    HWND owner;
+    DWORD process_id = 0;
+    HANDLE process;
+    wchar_t path[MAX_PATH];
+    DWORD length = ARRAYSIZE(path);
+    const wchar_t *basename;
+
+    owner = GetClipboardOwner();
+    if (!owner || !GetWindowThreadProcessId(owner, &process_id) ||
+        process_id == 0)
+        return FALSE;
+    process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id);
+    if (!process)
+        return FALSE;
+    if (!QueryFullProcessImageNameW(process, 0, path, &length)) {
+        CloseHandle(process);
+        return FALSE;
+    }
+    CloseHandle(process);
+    basename = wcsrchr(path, L'\\');
+    basename = basename ? basename + 1 : path;
+    return lstrcmpiW(basename, L"GameViewer.exe") == 0;
+}
+
+static BOOL read_clipboard_utf8(char **output, DWORD *output_size)
+{
+    HANDLE handle;
+    const wchar_t *source;
+    SIZE_T allocation_bytes;
+    SIZE_T source_units;
+    SIZE_T index;
+    wchar_t *normalized;
+    SIZE_T normalized_units = 0;
+    int bytes;
+    char *result;
+
+    *output = NULL;
+    *output_size = 0;
+    if (!OpenClipboard(NULL))
+        return FALSE;
+    handle = GetClipboardData(CF_UNICODETEXT);
+    if (!handle) {
+        CloseClipboard();
+        return FALSE;
+    }
+    source = GlobalLock(handle);
+    allocation_bytes = GlobalSize(handle);
+    if (!source || allocation_bytes < sizeof(wchar_t) ||
+        allocation_bytes / sizeof(wchar_t) > UURB_CLIPBOARD_MAX_UNITS) {
+        if (source)
+            GlobalUnlock(handle);
+        CloseClipboard();
+        return FALSE;
+    }
+    source_units = allocation_bytes / sizeof(wchar_t);
+    for (index = 0; index < source_units && source[index] != L'\0'; index++)
+        ;
+    if (index == source_units) {
+        GlobalUnlock(handle);
+        CloseClipboard();
+        return FALSE;
+    }
+    normalized = HeapAlloc(GetProcessHeap(), 0,
+                           (index + 1) * sizeof(wchar_t));
+    if (!normalized) {
+        GlobalUnlock(handle);
+        CloseClipboard();
+        return FALSE;
+    }
+    for (source_units = 0; source_units < index; source_units++) {
+        wchar_t character = source[source_units];
+
+        if (character == L'\0') {
+            HeapFree(GetProcessHeap(), 0, normalized);
+            GlobalUnlock(handle);
+            CloseClipboard();
+            return FALSE;
+        }
+        if (character == L'\r') {
+            normalized[normalized_units++] = L'\n';
+            if (source_units + 1 < index && source[source_units + 1] == L'\n')
+                source_units++;
+        } else {
+            normalized[normalized_units++] = character;
+        }
+    }
+    GlobalUnlock(handle);
+    CloseClipboard();
+    if (normalized_units == 0) {
+        HeapFree(GetProcessHeap(), 0, normalized);
+        return FALSE;
+    }
+    bytes = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, normalized,
+                                (int)normalized_units, NULL, 0, NULL, NULL);
+    if (bytes <= 0 || (DWORD)bytes > UURB_X11_CLIPBOARD_MAX_TEXT_BYTES) {
+        HeapFree(GetProcessHeap(), 0, normalized);
+        return FALSE;
+    }
+    result = HeapAlloc(GetProcessHeap(), 0, (SIZE_T)bytes);
+    if (!result || WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                       normalized, (int)normalized_units,
+                                       result, bytes, NULL, NULL) != bytes) {
+        if (result)
+            HeapFree(GetProcessHeap(), 0, result);
+        HeapFree(GetProcessHeap(), 0, normalized);
+        return FALSE;
+    }
+    HeapFree(GetProcessHeap(), 0, normalized);
+    *output = result;
+    *output_size = (DWORD)bytes;
+    return TRUE;
+}
+
+static BOOL forward_current_clipboard(DWORD sequence)
+{
+    uurb_x11_clipboard_request request;
+    uurb_x11_clipboard_response response;
+    char *text = NULL;
+    DWORD text_size;
+    BOOL sent = FALSE;
+
+    if (!owner_is_gameviewer() || !read_clipboard_utf8(&text, &text_size))
+        return FALSE;
+    if (!connect_clipboard_listener())
+        goto cleanup;
+    request.magic = UURB_X11_CLIPBOARD_MAGIC;
+    request.sequence = sequence;
+    request.text_bytes = text_size;
+    request.reserved = 0;
+    if (!socket_write_all(clipboard_socket, &request, sizeof(request)) ||
+        !socket_write_all(clipboard_socket, text, (int)text_size) ||
+        !socket_read_all(clipboard_socket, &response, sizeof(response)) ||
+        response.magic != UURB_X11_CLIPBOARD_MAGIC ||
+        response.sequence != sequence || response.result != text_size ||
+        response.error != 0) {
+        close_clipboard_socket();
+        goto cleanup;
+    }
+    sent = TRUE;
+
+cleanup:
+    HeapFree(GetProcessHeap(), 0, text);
+    return sent;
+}
+
+int wmain(void)
+{
+    DWORD delivered_sequence = 0;
+
+    if (!configure_bridge())
+        return 2;
+    for (;;) {
+        DWORD sequence = GetClipboardSequenceNumber();
+
+        if (sequence != 0 && sequence != delivered_sequence &&
+            forward_current_clipboard(sequence))
+            delivered_sequence = sequence;
+        Sleep(UURB_CLIPBOARD_POLL_MS);
+    }
+}

--- a/src/uu_wine_clipboard_bridge.c
+++ b/src/uu_wine_clipboard_bridge.c
@@ -15,6 +15,15 @@ static SOCKET clipboard_socket = INVALID_SOCKET;
 static BOOL winsock_initialized;
 static unsigned short clipboard_port;
 static char clipboard_token[UURB_X11_CLIPBOARD_TOKEN_SIZE + 1];
+static unsigned int diagnostic_reports;
+
+static void report_clipboard_failure(const char *stage)
+{
+    if (diagnostic_reports++ < 64U) {
+        fprintf(stderr, "controller-clipboard-failure stage=%s\n", stage);
+        fflush(stderr);
+    }
+}
 
 static void close_clipboard_socket(void)
 {
@@ -142,10 +151,12 @@ static BOOL owner_is_gameviewer(void)
     wchar_t path[MAX_PATH];
     DWORD length = ARRAYSIZE(path);
     const wchar_t *basename;
+    const wchar_t *slash_basename;
 
     owner = GetClipboardOwner();
-    if (!owner || !GetWindowThreadProcessId(owner, &process_id) ||
-        process_id == 0)
+    if (!owner)
+        return FALSE;
+    if (!GetWindowThreadProcessId(owner, &process_id) || process_id == 0)
         return FALSE;
     process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_id);
     if (!process)
@@ -157,10 +168,17 @@ static BOOL owner_is_gameviewer(void)
     CloseHandle(process);
     basename = wcsrchr(path, L'\\');
     basename = basename ? basename + 1 : path;
+    /* Wine can expose a Unix-style path here, while Windows uses a
+     * backslash-separated DOS path.  Authorize the executable name, not one
+     * platform's path spelling. */
+    slash_basename = wcsrchr(basename, L'/');
+    if (slash_basename)
+        basename = slash_basename + 1;
     return lstrcmpiW(basename, L"GameViewer.exe") == 0;
 }
 
-static BOOL read_clipboard_utf8(char **output, DWORD *output_size)
+static BOOL read_clipboard_utf8(DWORD expected_sequence, char **output,
+                                DWORD *output_size)
 {
     HANDLE handle;
     const wchar_t *source;
@@ -176,6 +194,17 @@ static BOOL read_clipboard_utf8(char **output, DWORD *output_size)
     *output_size = 0;
     if (!OpenClipboard(NULL))
         return FALSE;
+    /* The sequence and owner are one authorization decision.  Checking the
+     * owner before OpenClipboard leaves a race where another process can take
+     * the clipboard between the check and the read. */
+    if (GetClipboardSequenceNumber() != expected_sequence) {
+        CloseClipboard();
+        return FALSE;
+    }
+    if (!owner_is_gameviewer()) {
+        CloseClipboard();
+        return FALSE;
+    }
     handle = GetClipboardData(CF_UNICODETEXT);
     if (!handle) {
         CloseClipboard();
@@ -223,6 +252,16 @@ static BOOL read_clipboard_utf8(char **output, DWORD *output_size)
         }
     }
     GlobalUnlock(handle);
+    if (GetClipboardSequenceNumber() != expected_sequence) {
+        CloseClipboard();
+        HeapFree(GetProcessHeap(), 0, normalized);
+        return FALSE;
+    }
+    if (!owner_is_gameviewer()) {
+        CloseClipboard();
+        HeapFree(GetProcessHeap(), 0, normalized);
+        return FALSE;
+    }
     CloseClipboard();
     if (normalized_units == 0) {
         HeapFree(GetProcessHeap(), 0, normalized);
@@ -257,10 +296,12 @@ static BOOL forward_current_clipboard(DWORD sequence)
     DWORD text_size;
     BOOL sent = FALSE;
 
-    if (!owner_is_gameviewer() || !read_clipboard_utf8(&text, &text_size))
+    if (!read_clipboard_utf8(sequence, &text, &text_size))
         return FALSE;
-    if (!connect_clipboard_listener())
+    if (!connect_clipboard_listener()) {
+        report_clipboard_failure("connect");
         goto cleanup;
+    }
     request.magic = UURB_X11_CLIPBOARD_MAGIC;
     request.sequence = sequence;
     request.text_bytes = text_size;
@@ -271,6 +312,7 @@ static BOOL forward_current_clipboard(DWORD sequence)
         response.magic != UURB_X11_CLIPBOARD_MAGIC ||
         response.sequence != sequence || response.result != text_size ||
         response.error != 0) {
+        report_clipboard_failure("native-owner");
         close_clipboard_socket();
         goto cleanup;
     }
@@ -283,10 +325,17 @@ cleanup:
 
 int wmain(void)
 {
-    DWORD delivered_sequence = 0;
+    DWORD delivered_sequence;
 
     if (!configure_bridge())
         return 2;
+    /* Do not replay whatever happened to be in GameViewer's clipboard before
+     * this helper was started.  Only sequence changes observed after startup
+     * are eligible for forwarding. */
+    delivered_sequence = GetClipboardSequenceNumber();
+    fprintf(stderr,
+            "Wine clipboard companion ready; direction=controller-to-host-only.\n");
+    fflush(stderr);
     for (;;) {
         DWORD sequence = GetClipboardSequenceNumber();
 

--- a/src/uu_x11_clipboard.c
+++ b/src/uu_x11_clipboard.c
@@ -1,0 +1,388 @@
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "x11_clipboard_protocol.h"
+
+static volatile sig_atomic_t stop_requested;
+static volatile sig_atomic_t listener_fd = -1;
+static volatile sig_atomic_t active_client_fd = -1;
+static volatile sig_atomic_t clipboard_owner_pid = -1;
+static volatile sig_atomic_t primary_owner_pid = -1;
+
+static void stop_owner(volatile sig_atomic_t *owner_pid)
+{
+    pid_t pid = (pid_t)*owner_pid;
+    int status;
+
+    *owner_pid = -1;
+    if (pid <= 0)
+        return;
+    kill(pid, SIGTERM);
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+        ;
+}
+
+static void stop_owners(void)
+{
+    stop_owner(&clipboard_owner_pid);
+    stop_owner(&primary_owner_pid);
+}
+
+static void handle_signal(int signal_number)
+{
+    int fd;
+
+    (void)signal_number;
+    stop_requested = 1;
+    fd = listener_fd;
+    listener_fd = -1;
+    if (fd >= 0)
+        close(fd);
+    fd = active_client_fd;
+    active_client_fd = -1;
+    if (fd >= 0)
+        close(fd);
+}
+
+static bool read_all(int fd, void *buffer, size_t size)
+{
+    unsigned char *position = buffer;
+
+    while (size > 0) {
+        ssize_t received = recv(fd, position, size, 0);
+
+        if (received == 0)
+            return false;
+        if (received < 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        position += (size_t)received;
+        size -= (size_t)received;
+    }
+    return true;
+}
+
+static bool write_all(int fd, const void *buffer, size_t size)
+{
+    const unsigned char *position = buffer;
+
+    while (size > 0) {
+        ssize_t written = send(fd, position, size, MSG_NOSIGNAL);
+
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        if (written == 0)
+            return false;
+        position += (size_t)written;
+        size -= (size_t)written;
+    }
+    return true;
+}
+
+static bool write_fd_all(int fd, const char *buffer, size_t size)
+{
+    while (size > 0) {
+        ssize_t written = write(fd, buffer, size);
+
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        if (written == 0)
+            return false;
+        buffer += written;
+        size -= (size_t)written;
+    }
+    return true;
+}
+
+static bool valid_token(const char *token)
+{
+    size_t index;
+
+    if (!token || strlen(token) != UURB_X11_CLIPBOARD_TOKEN_SIZE)
+        return false;
+    for (index = 0; index < UURB_X11_CLIPBOARD_TOKEN_SIZE; index++) {
+        if (!isxdigit((unsigned char)token[index]))
+            return false;
+    }
+    return true;
+}
+
+/* Strict UTF-8 validation also rejects NUL.  The companion is the only
+ * intended sender, but content is nevertheless treated as untrusted. */
+static bool valid_utf8_text(const unsigned char *text, size_t size)
+{
+    size_t index = 0;
+
+    while (index < size) {
+        unsigned char first = text[index++];
+        uint32_t codepoint;
+        unsigned int continuation;
+
+        if (first == 0)
+            return false;
+        if (first < 0x80)
+            continue;
+        if (first >= 0xc2 && first <= 0xdf) {
+            codepoint = first & 0x1f;
+            continuation = 1;
+        } else if (first >= 0xe0 && first <= 0xef) {
+            codepoint = first & 0x0f;
+            continuation = 2;
+        } else if (first >= 0xf0 && first <= 0xf4) {
+            codepoint = first & 0x07;
+            continuation = 3;
+        } else {
+            return false;
+        }
+        if (index + continuation > size)
+            return false;
+        while (continuation-- > 0) {
+            unsigned char next = text[index++];
+
+            if ((next & 0xc0) != 0x80)
+                return false;
+            codepoint = (codepoint << 6) | (next & 0x3f);
+        }
+        if ((codepoint < 0x80) ||
+            (codepoint < 0x800 && first >= 0xe0) ||
+            (codepoint < 0x10000 && first >= 0xf0) ||
+            (codepoint >= 0xd800 && codepoint <= 0xdfff) ||
+            codepoint > 0x10ffff)
+            return false;
+    }
+    return true;
+}
+
+static bool start_owner(const char *selection, const char *text, size_t size,
+                        volatile sig_atomic_t *owner_pid)
+{
+    int input_pipe[2];
+    pid_t pid;
+
+    if (pipe2(input_pipe, O_CLOEXEC) != 0)
+        return false;
+    pid = fork();
+    if (pid < 0) {
+        close(input_pipe[0]);
+        close(input_pipe[1]);
+        return false;
+    }
+    if (pid == 0) {
+        int null_fd;
+
+        if (dup2(input_pipe[0], STDIN_FILENO) < 0)
+            _exit(126);
+        close(input_pipe[0]);
+        close(input_pipe[1]);
+        null_fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+        if (null_fd >= 0) {
+            dup2(null_fd, STDOUT_FILENO);
+            dup2(null_fd, STDERR_FILENO);
+            close(null_fd);
+        }
+        setenv("LC_ALL", "C.UTF-8", 1);
+        execl("/usr/bin/xclip", "xclip", "-selection", selection,
+              "-in", "-loops", "0", (char *)NULL);
+        _exit(127);
+    }
+    close(input_pipe[0]);
+    if (!write_fd_all(input_pipe[1], text, size)) {
+        close(input_pipe[1]);
+        kill(pid, SIGTERM);
+        waitpid(pid, NULL, 0);
+        return false;
+    }
+    close(input_pipe[1]);
+    *owner_pid = (sig_atomic_t)pid;
+    return true;
+}
+
+static bool replace_clipboard(const char *text, size_t size)
+{
+    volatile sig_atomic_t old_clipboard = clipboard_owner_pid;
+    volatile sig_atomic_t old_primary = primary_owner_pid;
+
+    clipboard_owner_pid = primary_owner_pid = -1;
+    if (!start_owner("CLIPBOARD", text, size, &clipboard_owner_pid) ||
+        !start_owner("PRIMARY", text, size, &primary_owner_pid)) {
+        stop_owners();
+        clipboard_owner_pid = old_clipboard;
+        primary_owner_pid = old_primary;
+        return false;
+    }
+    stop_owner(&old_clipboard);
+    stop_owner(&old_primary);
+    return true;
+}
+
+static bool send_response(int client, uint32_t sequence, uint32_t result,
+                          uint32_t error)
+{
+    uurb_x11_clipboard_response response;
+
+    response.magic = UURB_X11_CLIPBOARD_MAGIC;
+    response.sequence = sequence;
+    response.result = result;
+    response.error = error;
+    return write_all(client, &response, sizeof(response));
+}
+
+static void serve_client(int client, const char *token)
+{
+    uurb_x11_clipboard_handshake handshake;
+
+    if (!read_all(client, &handshake, sizeof(handshake)) ||
+        handshake.magic != UURB_X11_CLIPBOARD_MAGIC ||
+        handshake.version != UURB_X11_CLIPBOARD_VERSION ||
+        memcmp(handshake.token, token, UURB_X11_CLIPBOARD_TOKEN_SIZE) != 0 ||
+        !send_response(client, 0, 1, 0))
+        return;
+
+    while (!stop_requested) {
+        uurb_x11_clipboard_request request;
+        char *text;
+        uint32_t error = 0;
+
+        if (!read_all(client, &request, sizeof(request)))
+            break;
+        if (request.magic != UURB_X11_CLIPBOARD_MAGIC || request.reserved != 0 ||
+            request.text_bytes == 0 ||
+            request.text_bytes > UURB_X11_CLIPBOARD_MAX_TEXT_BYTES) {
+            send_response(client, request.sequence, 0,
+                          UURB_X11_CLIPBOARD_ERROR_BAD_REQUEST);
+            break;
+        }
+        text = malloc((size_t)request.text_bytes + 1U);
+        if (!text)
+            break;
+        if (!read_all(client, text, request.text_bytes)) {
+            free(text);
+            break;
+        }
+        text[request.text_bytes] = '\0';
+        if (!valid_utf8_text((const unsigned char *)text, request.text_bytes))
+            error = UURB_X11_CLIPBOARD_ERROR_INVALID_TEXT;
+        else if (!replace_clipboard(text, request.text_bytes))
+            error = UURB_X11_CLIPBOARD_ERROR_OWNER;
+        free(text);
+        if (!send_response(client, request.sequence,
+                           error == 0 ? request.text_bytes : 0, error))
+            break;
+    }
+}
+
+static bool publish_port(const char *path, unsigned int port)
+{
+    char value[32];
+    int fd;
+    int length;
+
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+    if (fd < 0)
+        return false;
+    length = snprintf(value, sizeof(value), "%u\n", port);
+    if (write_fd_all(fd, value, (size_t)length)) {
+        fsync(fd);
+        close(fd);
+        return true;
+    }
+    close(fd);
+    return false;
+}
+
+static int create_listener(const char *ready_file)
+{
+    struct sockaddr_in address;
+    socklen_t address_size = sizeof(address);
+    int fd;
+
+    fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0)
+        return -1;
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(fd, (struct sockaddr *)&address, sizeof(address)) != 0 ||
+        listen(fd, 1) != 0 ||
+        getsockname(fd, (struct sockaddr *)&address, &address_size) != 0 ||
+        !publish_port(ready_file, ntohs(address.sin_port))) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static void usage(const char *program)
+{
+    fprintf(stderr, "usage: UURB_X11_CLIPBOARD_TOKEN=HEX64 %s --ready-file PATH\n",
+            program);
+}
+
+int main(int argc, char **argv)
+{
+    const char *token = getenv("UURB_X11_CLIPBOARD_TOKEN");
+    const char *ready_file = NULL;
+    struct sigaction action;
+    int status = EXIT_FAILURE;
+
+    if (argc == 3 && strcmp(argv[1], "--ready-file") == 0)
+        ready_file = argv[2];
+    if (!ready_file || ready_file[0] != '/' || !valid_token(token)) {
+        usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = handle_signal;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGINT, &action, NULL);
+    sigaction(SIGTERM, &action, NULL);
+    signal(SIGPIPE, SIG_IGN);
+
+    listener_fd = create_listener(ready_file);
+    if (listener_fd < 0) {
+        fprintf(stderr, "Cannot create the private X11 clipboard listener.\n");
+        goto cleanup;
+    }
+    fprintf(stderr, "X11 clipboard helper ready; direction=wine-to-host-only.\n");
+    while (!stop_requested) {
+        int client = accept(listener_fd, NULL, NULL);
+
+        if (client < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        active_client_fd = client;
+        serve_client(client, token);
+        active_client_fd = -1;
+        close(client);
+    }
+    status = stop_requested ? EXIT_SUCCESS : EXIT_FAILURE;
+
+cleanup:
+    stop_owners();
+    if (listener_fd >= 0)
+        close(listener_fd);
+    unlink(ready_file);
+    return status;
+}

--- a/src/uu_x11_clipboard.c
+++ b/src/uu_x11_clipboard.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <arpa/inet.h>
 #include <ctype.h>
+#include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -10,10 +11,36 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include "x11_clipboard_protocol.h"
+
+#ifndef UURB_XCLIP_PATH
+#define UURB_XCLIP_PATH "/usr/bin/xclip"
+#endif
+
+/* Match uu_x11_input.c: keep the helper buildable with runtime X11 libraries
+ * only, then prove that each foreground xclip owns its requested selection. */
+typedef struct _XDisplay Display;
+typedef int Bool;
+typedef unsigned long Atom;
+typedef unsigned long Window;
+typedef Display *(*x_open_display_fn)(const char *);
+typedef int (*x_close_display_fn)(Display *);
+typedef int (*x_sync_fn)(Display *, Bool);
+typedef Atom (*x_intern_atom_fn)(Display *, const char *, Bool);
+typedef Window (*x_get_selection_owner_fn)(Display *, Atom);
+
+typedef struct x11_api {
+    void *library;
+    x_open_display_fn open_display;
+    x_close_display_fn close_display;
+    x_sync_fn sync;
+    x_intern_atom_fn intern_atom;
+    x_get_selection_owner_fn get_selection_owner;
+} x11_api;
 
 static volatile sig_atomic_t stop_requested;
 static volatile sig_atomic_t listener_fd = -1;
@@ -25,11 +52,22 @@ static void stop_owner(volatile sig_atomic_t *owner_pid)
 {
     pid_t pid = (pid_t)*owner_pid;
     int status;
+    unsigned int attempt;
 
     *owner_pid = -1;
     if (pid <= 0)
         return;
     kill(pid, SIGTERM);
+    for (attempt = 0; attempt < 25; attempt++) {
+        pid_t result = waitpid(pid, &status, WNOHANG);
+
+        if (result == pid || (result < 0 && errno == ECHILD))
+            return;
+        if (result < 0 && errno != EINTR)
+            break;
+        usleep(2000);
+    }
+    kill(pid, SIGKILL);
     while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
         ;
 }
@@ -127,6 +165,37 @@ static bool valid_token(const char *token)
     return true;
 }
 
+static bool load_x11_api(x11_api *api)
+{
+    memset(api, 0, sizeof(*api));
+    api->library = dlopen("libX11.so.6", RTLD_NOW | RTLD_LOCAL);
+    if (!api->library)
+        return false;
+    api->open_display = (x_open_display_fn)dlsym(api->library,
+                                                 "XOpenDisplay");
+    api->close_display = (x_close_display_fn)dlsym(api->library,
+                                                   "XCloseDisplay");
+    api->sync = (x_sync_fn)dlsym(api->library, "XSync");
+    api->intern_atom = (x_intern_atom_fn)dlsym(api->library,
+                                               "XInternAtom");
+    api->get_selection_owner = (x_get_selection_owner_fn)dlsym(
+        api->library, "XGetSelectionOwner");
+    if (!api->open_display || !api->close_display || !api->sync ||
+        !api->intern_atom || !api->get_selection_owner) {
+        dlclose(api->library);
+        memset(api, 0, sizeof(*api));
+        return false;
+    }
+    return true;
+}
+
+static void unload_x11_api(x11_api *api)
+{
+    if (api->library)
+        dlclose(api->library);
+    memset(api, 0, sizeof(*api));
+}
+
 /* Strict UTF-8 validation also rejects NUL.  The companion is the only
  * intended sender, but content is nevertheless treated as untrusted. */
 static bool valid_utf8_text(const unsigned char *text, size_t size)
@@ -173,11 +242,22 @@ static bool valid_utf8_text(const unsigned char *text, size_t size)
     return true;
 }
 
-static bool start_owner(const char *selection, const char *text, size_t size,
+static bool start_owner(const x11_api *api, Display *display,
+                        const char *selection, const char *text, size_t size,
                         volatile sig_atomic_t *owner_pid)
 {
+    Atom selection_atom;
     int input_pipe[2];
     pid_t pid;
+    Window previous_owner;
+    Window current_owner = 0;
+    unsigned int attempt;
+
+    selection_atom = api->intern_atom(display, selection, 0);
+    if (selection_atom == 0)
+        return false;
+    api->sync(display, 0);
+    previous_owner = api->get_selection_owner(display, selection_atom);
 
     if (pipe2(input_pipe, O_CLOEXEC) != 0)
         return false;
@@ -201,35 +281,66 @@ static bool start_owner(const char *selection, const char *text, size_t size,
             close(null_fd);
         }
         setenv("LC_ALL", "C.UTF-8", 1);
-        execl("/usr/bin/xclip", "xclip", "-selection", selection,
-              "-in", "-loops", "0", (char *)NULL);
+        /* -verbose keeps xclip in the foreground.  Without it xclip forks,
+         * leaving the launcher PID unable to supervise or clean up the real
+         * X11 selection owner. */
+        execl(UURB_XCLIP_PATH, "xclip", "-selection", selection,
+              "-in", "-loops", "0", "-verbose", (char *)NULL);
         _exit(127);
     }
     close(input_pipe[0]);
+    *owner_pid = (sig_atomic_t)pid;
     if (!write_fd_all(input_pipe[1], text, size)) {
         close(input_pipe[1]);
-        kill(pid, SIGTERM);
-        waitpid(pid, NULL, 0);
+        stop_owner(owner_pid);
         return false;
     }
     close(input_pipe[1]);
-    *owner_pid = (sig_atomic_t)pid;
-    return true;
+
+    for (attempt = 0; attempt < 100; attempt++) {
+        int status;
+        pid_t result;
+
+        api->sync(display, 0);
+        current_owner = api->get_selection_owner(display, selection_atom);
+        if (current_owner != 0 && current_owner != previous_owner)
+            return true;
+        result = waitpid(pid, &status, WNOHANG);
+        if (result == pid || (result < 0 && errno == ECHILD)) {
+            *owner_pid = -1;
+            return false;
+        }
+        if (result < 0 && errno != EINTR)
+            break;
+        usleep(5000);
+    }
+    stop_owner(owner_pid);
+    return false;
 }
 
-static bool replace_clipboard(const char *text, size_t size)
+static bool replace_clipboard(const x11_api *api, Display *display,
+                              const char *text, size_t size)
 {
     volatile sig_atomic_t old_clipboard = clipboard_owner_pid;
     volatile sig_atomic_t old_primary = primary_owner_pid;
+    volatile sig_atomic_t new_clipboard = -1;
+    volatile sig_atomic_t new_primary = -1;
 
-    clipboard_owner_pid = primary_owner_pid = -1;
-    if (!start_owner("CLIPBOARD", text, size, &clipboard_owner_pid) ||
-        !start_owner("PRIMARY", text, size, &primary_owner_pid)) {
-        stop_owners();
-        clipboard_owner_pid = old_clipboard;
-        primary_owner_pid = old_primary;
+    if (!start_owner(api, display, "CLIPBOARD", text, size,
+                     &new_clipboard) ||
+        !start_owner(api, display, "PRIMARY", text, size, &new_primary)) {
+        stop_owner(&new_clipboard);
+        stop_owner(&new_primary);
+        /* A partial X11 handoff can already have displaced either old owner.
+         * Do not restore stale PIDs as if they still owned the selections. */
+        stop_owner(&old_clipboard);
+        stop_owner(&old_primary);
+        clipboard_owner_pid = -1;
+        primary_owner_pid = -1;
         return false;
     }
+    clipboard_owner_pid = new_clipboard;
+    primary_owner_pid = new_primary;
     stop_owner(&old_clipboard);
     stop_owner(&old_primary);
     return true;
@@ -247,7 +358,20 @@ static bool send_response(int client, uint32_t sequence, uint32_t result,
     return write_all(client, &response, sizeof(response));
 }
 
-static void serve_client(int client, const char *token)
+static bool set_client_deadlines(int client)
+{
+    struct timeval timeout;
+
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+    return setsockopt(client, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                      sizeof(timeout)) == 0 &&
+           setsockopt(client, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+                      sizeof(timeout)) == 0;
+}
+
+static void serve_client(int client, const char *token,
+                         const x11_api *api, Display *display)
 {
     uurb_x11_clipboard_handshake handshake;
 
@@ -282,7 +406,7 @@ static void serve_client(int client, const char *token)
         text[request.text_bytes] = '\0';
         if (!valid_utf8_text((const unsigned char *)text, request.text_bytes))
             error = UURB_X11_CLIPBOARD_ERROR_INVALID_TEXT;
-        else if (!replace_clipboard(text, request.text_bytes))
+        else if (!replace_clipboard(api, display, text, request.text_bytes))
             error = UURB_X11_CLIPBOARD_ERROR_OWNER;
         free(text);
         if (!send_response(client, request.sequence,
@@ -342,8 +466,12 @@ int main(int argc, char **argv)
 {
     const char *token = getenv("UURB_X11_CLIPBOARD_TOKEN");
     const char *ready_file = NULL;
+    Display *display = NULL;
     struct sigaction action;
     int status = EXIT_FAILURE;
+    x11_api api;
+
+    memset(&api, 0, sizeof(api));
 
     if (argc == 3 && strcmp(argv[1], "--ready-file") == 0)
         ready_file = argv[2];
@@ -358,6 +486,10 @@ int main(int argc, char **argv)
     sigaction(SIGTERM, &action, NULL);
     signal(SIGPIPE, SIG_IGN);
 
+    if (!load_x11_api(&api) || !(display = api.open_display(NULL))) {
+        fprintf(stderr, "Cannot inspect X11 clipboard ownership.\n");
+        goto cleanup;
+    }
     listener_fd = create_listener(ready_file);
     if (listener_fd < 0) {
         fprintf(stderr, "Cannot create the private X11 clipboard listener.\n");
@@ -372,8 +504,12 @@ int main(int argc, char **argv)
                 continue;
             break;
         }
+        if (!set_client_deadlines(client)) {
+            close(client);
+            continue;
+        }
         active_client_fd = client;
-        serve_client(client, token);
+        serve_client(client, token, &api, display);
         active_client_fd = -1;
         close(client);
     }
@@ -383,6 +519,9 @@ cleanup:
     stop_owners();
     if (listener_fd >= 0)
         close(listener_fd);
+    if (display)
+        api.close_display(display);
+    unload_x11_api(&api);
     unlink(ready_file);
     return status;
 }

--- a/src/x11_clipboard_protocol.h
+++ b/src/x11_clipboard_protocol.h
@@ -1,0 +1,39 @@
+#ifndef UURB_X11_CLIPBOARD_PROTOCOL_H
+#define UURB_X11_CLIPBOARD_PROTOCOL_H
+
+#include <stdint.h>
+
+/* This intentionally has a protocol of its own.  Text copied by a UU
+ * controller arrives in Wine's Win32 clipboard, not in the private X11
+ * selection.  The listener below only writes the selected host X11 desktop;
+ * it has no receive path back into Wine or VNC. */
+#define UURB_X11_CLIPBOARD_MAGIC UINT32_C(0x43425555)
+#define UURB_X11_CLIPBOARD_VERSION UINT32_C(1)
+#define UURB_X11_CLIPBOARD_TOKEN_SIZE 64
+#define UURB_X11_CLIPBOARD_MAX_TEXT_BYTES UINT32_C(4194304)
+
+#define UURB_X11_CLIPBOARD_ERROR_BAD_REQUEST UINT32_C(0x3001)
+#define UURB_X11_CLIPBOARD_ERROR_INVALID_TEXT UINT32_C(0x3002)
+#define UURB_X11_CLIPBOARD_ERROR_OWNER UINT32_C(0x3003)
+
+typedef struct uurb_x11_clipboard_handshake {
+    uint32_t magic;
+    uint32_t version;
+    char token[UURB_X11_CLIPBOARD_TOKEN_SIZE];
+} uurb_x11_clipboard_handshake;
+
+typedef struct uurb_x11_clipboard_request {
+    uint32_t magic;
+    uint32_t sequence;
+    uint32_t text_bytes;
+    uint32_t reserved;
+} uurb_x11_clipboard_request;
+
+typedef struct uurb_x11_clipboard_response {
+    uint32_t magic;
+    uint32_t sequence;
+    uint32_t result;
+    uint32_t error;
+} uurb_x11_clipboard_response;
+
+#endif

--- a/tests/probes/uu_controller_clipboard_fixture.c
+++ b/tests/probes/uu_controller_clipboard_fixture.c
@@ -1,0 +1,64 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <wchar.h>
+
+#ifndef UURB_FIXTURE_TEXT
+#define UURB_FIXTURE_TEXT L"controller clipboard fixture"
+#endif
+
+static LRESULT CALLBACK fixture_window_proc(HWND window, UINT message,
+                                             WPARAM wparam, LPARAM lparam)
+{
+    return DefWindowProcW(window, message, wparam, lparam);
+}
+
+int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
+                    int show_command)
+{
+    static const wchar_t class_name[] = L"UURBClipboardFixture";
+    static const wchar_t text[] = UURB_FIXTURE_TEXT;
+    WNDCLASSW window_class;
+    HGLOBAL allocation;
+    HWND window;
+    wchar_t *destination;
+
+    (void)previous;
+    (void)command_line;
+    (void)show_command;
+    ZeroMemory(&window_class, sizeof(window_class));
+    window_class.lpfnWndProc = fixture_window_proc;
+    window_class.hInstance = instance;
+    window_class.lpszClassName = class_name;
+    if (!RegisterClassW(&window_class) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
+        return 2;
+    window = CreateWindowExW(0, class_name, L"UU clipboard fixture", 0,
+                             0, 0, 1, 1, NULL, NULL, instance, NULL);
+    if (!window || !OpenClipboard(window))
+        return 3;
+    if (!EmptyClipboard()) {
+        CloseClipboard();
+        return 4;
+    }
+    allocation = GlobalAlloc(GMEM_MOVEABLE, sizeof(text));
+    if (!allocation) {
+        CloseClipboard();
+        return 5;
+    }
+    destination = GlobalLock(allocation);
+    if (!destination) {
+        GlobalFree(allocation);
+        CloseClipboard();
+        return 6;
+    }
+    memcpy(destination, text, sizeof(text));
+    GlobalUnlock(allocation);
+    if (!SetClipboardData(CF_UNICODETEXT, allocation)) {
+        GlobalFree(allocation);
+        CloseClipboard();
+        return 7;
+    }
+    CloseClipboard();
+    Sleep(2000);
+    DestroyWindow(window);
+    return 0;
+}

--- a/tests/probes/uu_controller_clipboard_fixture.c
+++ b/tests/probes/uu_controller_clipboard_fixture.c
@@ -1,5 +1,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <stdio.h>
 #include <wchar.h>
 
 #ifndef UURB_FIXTURE_TEXT
@@ -16,8 +17,7 @@ static LRESULT CALLBACK fixture_window_proc(HWND window, UINT message,
     return DefWindowProcW(window, message, wparam, lparam);
 }
 
-int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
-                    int show_command)
+int wmain(void)
 {
     static const wchar_t class_name[] = L"UURBClipboardFixture";
     static const wchar_t text[] = UURB_FIXTURE_TEXT;
@@ -28,17 +28,15 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
     ULONGLONG deadline;
     wchar_t *destination;
 
-    (void)previous;
-    (void)command_line;
-    (void)show_command;
     ZeroMemory(&window_class, sizeof(window_class));
     window_class.lpfnWndProc = fixture_window_proc;
-    window_class.hInstance = instance;
+    window_class.hInstance = GetModuleHandleW(NULL);
     window_class.lpszClassName = class_name;
     if (!RegisterClassW(&window_class) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
         return 2;
     window = CreateWindowExW(0, class_name, L"UU clipboard fixture", 0,
-                             0, 0, 1, 1, NULL, NULL, instance, NULL);
+                             0, 0, 1, 1, NULL, NULL,
+                             window_class.hInstance, NULL);
     if (!window || !OpenClipboard(window))
         return 3;
     if (!EmptyClipboard()) {
@@ -64,6 +62,8 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
         return 7;
     }
     CloseClipboard();
+    fprintf(stderr, "fixture clipboard ready\n");
+    fflush(stderr);
     deadline = GetTickCount64() + UURB_FIXTURE_HOLD_MS;
     while (GetTickCount64() < deadline) {
         while (PeekMessageW(&message, NULL, 0, 0, PM_REMOVE)) {

--- a/tests/probes/uu_controller_clipboard_fixture.c
+++ b/tests/probes/uu_controller_clipboard_fixture.c
@@ -6,6 +6,10 @@
 #define UURB_FIXTURE_TEXT L"controller clipboard fixture"
 #endif
 
+#ifndef UURB_FIXTURE_HOLD_MS
+#define UURB_FIXTURE_HOLD_MS 2000UL
+#endif
+
 static LRESULT CALLBACK fixture_window_proc(HWND window, UINT message,
                                              WPARAM wparam, LPARAM lparam)
 {
@@ -20,6 +24,8 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
     WNDCLASSW window_class;
     HGLOBAL allocation;
     HWND window;
+    MSG message;
+    ULONGLONG deadline;
     wchar_t *destination;
 
     (void)previous;
@@ -58,7 +64,14 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE previous, PWSTR command_line,
         return 7;
     }
     CloseClipboard();
-    Sleep(2000);
+    deadline = GetTickCount64() + UURB_FIXTURE_HOLD_MS;
+    while (GetTickCount64() < deadline) {
+        while (PeekMessageW(&message, NULL, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+        Sleep(10);
+    }
     DestroyWindow(window);
     return 0;
 }

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -741,7 +741,26 @@ x11_input_pid= terminal_bridge_pid=
         launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
 
         self.assertIn("+clipboard", launcher)
-        self.assertNotIn("-clipboard", launcher)
+        self.assertNotIn("\n        -clipboard \\\n", launcher)
+
+    def test_controller_clipboard_bridge_is_one_way_and_owner_scoped(self):
+        launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()
+        companion = (
+            REPOSITORY / "src" / "uu_wine_clipboard_bridge.c"
+        ).read_text()
+        listener = (REPOSITORY / "src" / "uu_x11_clipboard.c").read_text()
+
+        self.assertIn('L"GameViewer.exe"', companion)
+        self.assertIn("GetClipboardOwner()", companion)
+        self.assertIn("GetClipboardData(CF_UNICODETEXT)", companion)
+        self.assertIn("INADDR_LOOPBACK", companion)
+        self.assertIn("INADDR_LOOPBACK", listener)
+        self.assertIn('start_owner("CLIPBOARD"', listener)
+        self.assertIn('start_owner("PRIMARY"', listener)
+        self.assertNotIn("SetClipboardData", listener)
+        self.assertNotIn("SendInput", companion + listener)
+        self.assertIn("-seldir recv", launcher)
+        self.assertIn("-ServerCutText=0", launcher)
 
     def test_opt_in_cursor_guard_uses_absolute_ungrabbed_mouse(self):
         launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()

--- a/tests/test_runtime_scripts.py
+++ b/tests/test_runtime_scripts.py
@@ -560,7 +560,8 @@ winlogon_pid=$xvfb_pid
 input_broker_pid=$xvfb_pid
 server_supervisor_pid=$xvfb_pid
 grd_pid= freerdp_pid= desktop_x11vnc_pid= vncviewer_pid=
-x11_input_pid= terminal_bridge_pid=
+x11_input_pid= x11_clipboard_pid= wine_clipboard_bridge_pid=
+terminal_bridge_pid=
 '''
         for status in (0, 7):
             with self.subTest(status=status):
@@ -749,18 +750,45 @@ x11_input_pid= terminal_bridge_pid=
             REPOSITORY / "src" / "uu_wine_clipboard_bridge.c"
         ).read_text()
         listener = (REPOSITORY / "src" / "uu_x11_clipboard.c").read_text()
+        fixture = (
+            REPOSITORY / "tests" / "probes" / "uu_controller_clipboard_fixture.c"
+        ).read_text()
+        functional = (
+            REPOSITORY / "scripts" / "test-controller-clipboard.sh"
+        ).read_text()
+        workflow = (
+            REPOSITORY / ".github" / "workflows" / "validate.yml"
+        ).read_text()
 
         self.assertIn('L"GameViewer.exe"', companion)
         self.assertIn("GetClipboardOwner()", companion)
         self.assertIn("GetClipboardData(CF_UNICODETEXT)", companion)
+        self.assertIn("delivered_sequence = GetClipboardSequenceNumber();", companion)
+        self.assertGreaterEqual(companion.count("owner_is_gameviewer()"), 2)
+        self.assertGreaterEqual(
+            companion.count("GetClipboardSequenceNumber() != expected_sequence"),
+            2,
+        )
         self.assertIn("INADDR_LOOPBACK", companion)
         self.assertIn("INADDR_LOOPBACK", listener)
-        self.assertIn('start_owner("CLIPBOARD"', listener)
-        self.assertIn('start_owner("PRIMARY"', listener)
+        self.assertIn('"CLIPBOARD", text, size', listener)
+        self.assertIn('"PRIMARY", text, size', listener)
+        self.assertIn('"-verbose"', listener)
+        self.assertIn("XGetSelectionOwner", listener)
+        self.assertIn("SO_RCVTIMEO", listener)
+        self.assertIn("SO_SNDTIMEO", listener)
         self.assertNotIn("SetClipboardData", listener)
         self.assertNotIn("SendInput", companion + listener)
         self.assertIn("-seldir recv", launcher)
         self.assertIn("-ServerCutText=0", launcher)
+        self.assertIn('if [[ "$desktop_relay" != vnc ]]; then', launcher)
+        self.assertIn('"$x11_clipboard_pid"', launcher)
+        self.assertIn('"$wine_clipboard_bridge_pid"', launcher)
+        self.assertIn("PeekMessageW", fixture)
+        self.assertIn("startup-baseline=existing content ignored", functional)
+        self.assertIn("failure-mode=xclip failure rejected", functional)
+        self.assertIn("lifecycle=deadlines bounded and owner children reaped", functional)
+        self.assertIn("./scripts/test-controller-clipboard.sh", workflow)
 
     def test_opt_in_cursor_guard_uses_absolute_ungrabbed_mouse(self):
         launcher = (REPOSITORY / "scripts" / "uu-remote-bridge").read_text()


### PR DESCRIPTION
## Summary

- forward controller text that reaches GameViewer's Wine `CF_UNICODETEXT` clipboard to the selected host X11 `CLIPBOARD` and `PRIMARY`
- require the Win32 clipboard owner to be exactly `GameViewer.exe`
- use a bounded, token-authenticated loopback protocol with UTF-16/UTF-8 validation and CRLF normalization
- preserve the existing one-way VNC safeguards (`x11vnc -seldir recv`, `ServerCutText=0`, `SendPrimary=0`) and never inject a paste key
- integrate both optional helpers into the deterministic build, installer, runtime cleanup, documentation, and tests

## Problem

On the affected Ubuntu 24.04 X11 host, text copied on a Mac controller arrived in GameViewer's standard Win32 clipboard under Wine, but Wine did not publish an X11 selection on the private display. The VNC relay therefore had nothing to forward, and Ubuntu pasted its previous local clipboard value.

The new Wine companion observes clipboard sequence changes but forwards only bounded `CF_UNICODETEXT` owned by `GameViewer.exe`. A separate native listener writes that text to the physical X11 desktop. It has no host-clipboard read path, so the existing feedback-loop protections remain intact. Images, rich text, and files are intentionally out of scope.

## Validation

- `./scripts/build-compat.sh build/compat-pr`
- `python3 -m unittest discover -s tests` — 139 tests passed
- `./scripts/test-controller-clipboard.sh`
  - GameViewer-owned Chinese/English multiline text arrived exactly on a separate host X display
  - a non-GameViewer Wine clipboard owner was ignored
  - Wine and host use separate Xvfb displays to match the production isolation boundary
- live Mac → UU → Ubuntu testing: repeated English, Chinese, numeric, and multiline copies all succeeded; the UU service remained stable with no restart
